### PR TITLE
Fix #49: Render basketball half court on canvas

### DIFF
--- a/src/app/play/[id]/page.tsx
+++ b/src/app/play/[id]/page.tsx
@@ -1,3 +1,5 @@
+import Court from "@/components/court/Court";
+
 interface PlayEditorPageProps {
   params: { id: string };
 }
@@ -21,22 +23,22 @@ export default function PlayEditorPage({ params }: PlayEditorPageProps) {
       </header>
       <div className="flex flex-1 overflow-hidden">
         {/* Tools Panel */}
-        <aside className="w-16 border-r border-gray-200 bg-gray-50 flex flex-col items-center py-4 gap-3">
+        <aside className="flex w-16 flex-col items-center gap-3 border-r border-gray-200 bg-gray-50 py-4">
           <div className="text-xs text-gray-400">Tools</div>
         </aside>
         {/* Court Canvas */}
-        <div className="flex-1 bg-gray-100 flex items-center justify-center">
-          <p className="text-gray-400">Court canvas coming soon</p>
+        <div className="flex flex-1 items-center justify-center overflow-auto bg-gray-100 p-4">
+          <Court className="w-full max-w-3xl" />
         </div>
         {/* Play Info Panel */}
         <aside className="w-64 border-l border-gray-200 bg-white p-4">
-          <h2 className="font-semibold text-gray-700 mb-2">Play Info</h2>
+          <h2 className="mb-2 font-semibold text-gray-700">Play Info</h2>
           <p className="text-sm text-gray-400">Play details and notes will appear here.</p>
         </aside>
       </div>
       {/* Scene Strip */}
       <footer className="border-t border-gray-200 bg-white p-2">
-        <p className="text-sm text-gray-400 text-center">Scene strip coming soon</p>
+        <p className="text-center text-sm text-gray-400">Scene strip coming soon</p>
       </footer>
     </main>
   );

--- a/src/components/court/Court.tsx
+++ b/src/components/court/Court.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+/**
+ * Court component — renders an NBA basketball half court on an HTML5 Canvas.
+ *
+ * Implements issue #49: Render basketball half court on canvas.
+ *
+ * Design:
+ *   - Light maple-wood court colour (#F5DEB3 / wheat) with darker line colour.
+ *   - All NBA standard markings: paint, free-throw line, free-throw circle,
+ *     three-point arc (with corner straights), restricted area arc,
+ *     backboard, basket/rim, and half-court line with centre-circle arc.
+ *   - Responsive: fills container width and maintains correct aspect ratio.
+ *   - Exposes a `courtToCanvas(x, y)` utility via the `onReady` callback so
+ *     downstream components can map normalised court coordinates to pixels.
+ */
+
+import { useEffect, useRef, useCallback } from "react";
+import {
+  COURT_ASPECT_RATIO,
+  BASKET_X,
+  BASKET_Y,
+  BASKET_RADIUS,
+  BACKBOARD_Y,
+  BACKBOARD_HALF_WIDTH,
+  LANE_LEFT,
+  LANE_RIGHT,
+  LANE_TOP,
+  CORNER_THREE_Y,
+  CORNER_THREE_LEFT_X,
+  CORNER_THREE_RIGHT_X,
+  FT_CIRCLE_CENTER_X,
+  FT_CIRCLE_CENTER_Y,
+  FT_CIRCLE_RADIUS,
+  CENTRE_CIRCLE_RADIUS,
+} from "./courtDimensions";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CourtVariant = "half" | "full";
+
+/** Maps a normalised court coordinate [0-1, 0-1] to canvas pixels. */
+export type CourtToCanvas = (normX: number, normY: number) => { x: number; y: number };
+
+export interface CourtReadyPayload {
+  canvas: HTMLCanvasElement;
+  courtToCanvas: CourtToCanvas;
+  /** Canvas width in CSS pixels. */
+  width: number;
+  /** Canvas height in CSS pixels. */
+  height: number;
+}
+
+export interface CourtProps {
+  /**
+   * Optional callback fired whenever the court is (re-)drawn.
+   * Useful for overlaying players or annotations on top.
+   */
+  onReady?: (payload: CourtReadyPayload) => void;
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Colours
+// ---------------------------------------------------------------------------
+const COLOR_COURT = "#F0C878"; // warm maple
+const COLOR_PAINT = "#E07B39"; // standard orange paint
+const COLOR_LINE = "#FFFFFF"; // white lines
+const COLOR_LINE_WIDTH_PX = 2; // base line width — scaled by canvas resolution
+
+// ---------------------------------------------------------------------------
+// Drawing helpers
+// ---------------------------------------------------------------------------
+
+function drawCourt(canvas: HTMLCanvasElement): void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  const W = canvas.width;
+  const H = canvas.height;
+
+  // Helpers to convert normalised [0-1] court coords → canvas pixels
+  const cx = (nx: number) => nx * W;
+  const cy = (ny: number) => ny * H;
+  // Convert a normalised x-radius → pixels (uses W since x is scaled to width)
+  const rx = (nr: number) => nr * W;
+
+  // For arcs that need a pixel radius: the arc is based on the court's physical
+  // radius expressed relative to court width, but when rendered we need the
+  // pixel equivalent. Because W corresponds to COURT_WIDTH_FT and H to
+  // COURT_LENGTH_FT, a radius expressed in normalised-x units maps to rx(r)
+  // pixels in x but potentially a different number in y. We draw arcs in
+  // canvas space where 1px is not necessarily square, so we use a uniform
+  // scale based on W (width) and apply ctx.scale / ellipse where needed.
+  // To keep things simple we apply a non-uniform scale so that a single
+  // canvas unit = 1px in x direction, and squash y accordingly.
+
+  // Scale factor: when drawing a "circle" from physical coords, y must be
+  // scaled by H/W to convert from x-normalised radius to y-normalised radius.
+  const scaleY = H / W;
+
+  ctx.clearRect(0, 0, W, H);
+
+  // ------------------------------------------------------------------
+  // 1. Court background
+  // ------------------------------------------------------------------
+  ctx.fillStyle = COLOR_COURT;
+  ctx.fillRect(0, 0, W, H);
+
+  // ------------------------------------------------------------------
+  // 2. Paint (free-throw lane)
+  // ------------------------------------------------------------------
+  ctx.fillStyle = COLOR_PAINT;
+  ctx.fillRect(cx(LANE_LEFT), cy(LANE_TOP), cx(LANE_RIGHT) - cx(LANE_LEFT), cy(1) - cy(LANE_TOP));
+
+  // ------------------------------------------------------------------
+  // Setup line style
+  // ------------------------------------------------------------------
+  ctx.strokeStyle = COLOR_LINE;
+  ctx.lineWidth = COLOR_LINE_WIDTH_PX;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+
+  // ------------------------------------------------------------------
+  // 3. Court boundary
+  // ------------------------------------------------------------------
+  ctx.strokeRect(0, 0, W, H);
+
+  // ------------------------------------------------------------------
+  // 4. Half-court line
+  // ------------------------------------------------------------------
+  ctx.beginPath();
+  ctx.moveTo(0, cy(0));
+  ctx.lineTo(W, cy(0));
+  ctx.stroke();
+
+  // ------------------------------------------------------------------
+  // 5. Half-court centre-circle arc (only the half visible in this half)
+  //    The full centre circle has radius 6ft. We draw the semicircle that
+  //    extends into the half court (downward from y=0).
+  // ------------------------------------------------------------------
+  ctx.save();
+  ctx.scale(1, scaleY);
+  ctx.beginPath();
+  // Arc at (0.5*W, 0) with radius rx(CENTRE_CIRCLE_RADIUS)
+  // Draw the semicircle going into the court (0 to π in canvas coords)
+  ctx.arc(cx(0.5), 0, rx(CENTRE_CIRCLE_RADIUS), 0, Math.PI);
+  ctx.restore();
+  ctx.stroke();
+
+  // ------------------------------------------------------------------
+  // 6. Three-point arc
+  // The three-point line consists of:
+  //   a) Two corner straight segments (parallel to baseline)
+  //   b) An arc connecting them, centred on the basket
+  // ------------------------------------------------------------------
+
+  // We need to find the angles where the arc meets the corner-three y line.
+  // In normalised coords: basket is at (BASKET_X, BASKET_Y)
+  // Corner three y is at CORNER_THREE_Y
+  // The arc has radius THREE_POINT_RADIUS (in x-normalised units)
+  // But because we draw with non-uniform scale, we compute intersection angle
+  // in physical (normalised) space, then map to canvas.
+  //
+  // In normalised coords, the arc is an ellipse:
+  //   ((nx - BASKET_X) / THREE_POINT_RADIUS)^2 + ((ny - BASKET_Y) / (THREE_POINT_RADIUS * H/W))^2 = 1
+  // No — let's think in feet instead.
+  //
+  // Physical: basket at (25ft, basketY_ft) from top-left corner.
+  // THREE_POINT_RADIUS_FT = 23.75
+  // Corner straight at y = CORNER_THREE_Y * H (canvas px from top)
+  //
+  // dy_ft = (BASKET_Y - CORNER_THREE_Y) * COURT_LENGTH_FT (feet from basket to corner-line)
+  // dx_ft = sqrt(23.75^2 - dy_ft^2)
+  // Angles in the canvas's potentially non-square coordinate system require
+  // the ellipse approach.
+  //
+  // Simplest accurate approach: draw the arc using ctx.save()/scale so that
+  // the coordinate system becomes square (1 unit = 1 ft), then the arc is a
+  // true circle.
+
+  const FT_PER_PX_X = 50 / W; // feet per canvas pixel in x
+  const FT_PER_PX_Y = 47 / H; // feet per canvas pixel in y
+
+  // Save and transform to a "feet" coordinate system
+  ctx.save();
+  // Scale so that 1 canvas unit = 1 foot
+  ctx.scale(1 / FT_PER_PX_X, 1 / FT_PER_PX_Y);
+
+  // In ft coords:
+  const basketX_ft = BASKET_X * 50; // 25
+  const basketY_ft = BASKET_Y * 47;
+  const cornerY_ft = CORNER_THREE_Y * 47;
+  const leftCornerX_ft = CORNER_THREE_LEFT_X * 50; // 3
+  const rightCornerX_ft = CORNER_THREE_RIGHT_X * 50; // 47
+
+  // dy from basket to corner three line
+  const dy3 = basketY_ft - cornerY_ft; // positive, basket is below corner line
+  // dx from basket centre to where arc meets the corner line
+  const dx3 = Math.sqrt(23.75 * 23.75 - dy3 * dy3);
+
+  // Angle of the arc endpoints (measured from +x axis, clockwise in canvas)
+  // In canvas y increases downward, so atan2 convention: angle from +x going clockwise.
+  // Left endpoint: basket + (-dx3, -dy3) → angle = atan2(-dy3, -dx3)
+  // Right endpoint: basket + (dx3, -dy3)  → angle = atan2(-dy3,  dx3)
+  const arcAngleLeft = Math.atan2(-dy3, -dx3); // ~between -π and -π/2
+  const arcAngleRight = Math.atan2(-dy3, dx3); // ~between -π/2 and 0
+
+  ctx.strokeStyle = COLOR_LINE;
+  ctx.lineWidth = COLOR_LINE_WIDTH_PX * FT_PER_PX_X; // scale line width to ft coords
+
+  // Left corner three straight (from left sideline to arc start)
+  ctx.beginPath();
+  ctx.moveTo(leftCornerX_ft, cornerY_ft);
+  ctx.lineTo(basketX_ft - dx3, cornerY_ft);
+  ctx.stroke();
+
+  // Right corner three straight (from arc end to right sideline)
+  ctx.beginPath();
+  ctx.moveTo(basketX_ft + dx3, cornerY_ft);
+  ctx.lineTo(rightCornerX_ft, cornerY_ft);
+  ctx.stroke();
+
+  // Three-point arc (counterclockwise from right endpoint to left endpoint,
+  // going through the top of the arc toward the half-court line)
+  ctx.beginPath();
+  ctx.arc(basketX_ft, basketY_ft, 23.75, arcAngleRight, arcAngleLeft, true);
+  ctx.stroke();
+
+  // ------------------------------------------------------------------
+  // 7. Restricted area arc (4ft radius from basket)
+  // ------------------------------------------------------------------
+  // Draw semicircle from baseline to free-throw side (angles: π to 0 going counterclockwise,
+  // i.e. the portion inside the court, away from baseline)
+  // In canvas y-down: angles where y < basketY_ft are "upward" i.e. into the court.
+  // We want the arc on the side toward half-court (y < basketY).
+  // That's angles from π (left) to 0 (right), going counterclockwise (through top).
+  ctx.beginPath();
+  ctx.arc(basketX_ft, basketY_ft, 4, Math.PI, 0, true);
+  ctx.stroke();
+
+  ctx.restore(); // end ft coordinate system
+
+  // ------------------------------------------------------------------
+  // 8. Paint lane outline (drawn over paint fill)
+  // ------------------------------------------------------------------
+  ctx.beginPath();
+  ctx.strokeRect(cx(LANE_LEFT), cy(LANE_TOP), cx(LANE_RIGHT) - cx(LANE_LEFT), cy(1) - cy(LANE_TOP));
+
+  // ------------------------------------------------------------------
+  // 9. Free-throw line
+  // ------------------------------------------------------------------
+  ctx.beginPath();
+  ctx.moveTo(cx(LANE_LEFT), cy(FT_CIRCLE_CENTER_Y));
+  ctx.lineTo(cx(LANE_RIGHT), cy(FT_CIRCLE_CENTER_Y));
+  ctx.stroke();
+
+  // ------------------------------------------------------------------
+  // 10. Free-throw circle
+  //     Full circle: solid upper half (toward half court), dashed lower half
+  // ------------------------------------------------------------------
+  ctx.save();
+  ctx.scale(1, scaleY);
+
+  // Upper semicircle (solid) — into the half court (toward y=0)
+  ctx.beginPath();
+  ctx.arc(cx(FT_CIRCLE_CENTER_X), cy(FT_CIRCLE_CENTER_Y) / scaleY, rx(FT_CIRCLE_RADIUS), Math.PI, 0, true);
+  ctx.stroke();
+
+  // Lower semicircle (dashed) — into the paint (toward y=1)
+  ctx.setLineDash([rx(0.015), rx(0.015)]);
+  ctx.beginPath();
+  ctx.arc(cx(FT_CIRCLE_CENTER_X), cy(FT_CIRCLE_CENTER_Y) / scaleY, rx(FT_CIRCLE_RADIUS), 0, Math.PI, false);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  ctx.restore();
+
+  // ------------------------------------------------------------------
+  // 11. Backboard
+  // ------------------------------------------------------------------
+  ctx.beginPath();
+  ctx.moveTo(cx(BASKET_X - BACKBOARD_HALF_WIDTH), cy(BACKBOARD_Y));
+  ctx.lineTo(cx(BASKET_X + BACKBOARD_HALF_WIDTH), cy(BACKBOARD_Y));
+  ctx.stroke();
+
+  // ------------------------------------------------------------------
+  // 12. Basket / rim
+  // ------------------------------------------------------------------
+  ctx.save();
+  ctx.scale(1, scaleY);
+  ctx.beginPath();
+  ctx.arc(cx(BASKET_X), cy(BASKET_Y) / scaleY, rx(BASKET_RADIUS), 0, Math.PI * 2);
+  ctx.strokeStyle = COLOR_LINE;
+  ctx.stroke();
+  ctx.restore();
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function Court({ onReady, className }: CourtProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+
+    const dpr = window.devicePixelRatio ?? 1;
+    const cssWidth = container.clientWidth;
+    const cssHeight = Math.round(cssWidth / COURT_ASPECT_RATIO);
+
+    // Set CSS size
+    canvas.style.width = `${cssWidth}px`;
+    canvas.style.height = `${cssHeight}px`;
+
+    // Set backing store size (high-DPI)
+    canvas.width = Math.round(cssWidth * dpr);
+    canvas.height = Math.round(cssHeight * dpr);
+
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      ctx.scale(dpr, dpr);
+    }
+
+    drawCourt(canvas);
+
+    // Notify parent with coordinate conversion helper
+    if (onReady) {
+      const courtToCanvas: CourtToCanvas = (normX, normY) => ({
+        x: normX * cssWidth,
+        y: normY * cssHeight,
+      });
+      onReady({ canvas, courtToCanvas, width: cssWidth, height: cssHeight });
+    }
+  }, [onReady]);
+
+  useEffect(() => {
+    draw();
+
+    const observer = new ResizeObserver(() => draw());
+    const container = containerRef.current;
+    if (container) observer.observe(container);
+
+    return () => observer.disconnect();
+  }, [draw]);
+
+  return (
+    <div ref={containerRef} className={className ?? "w-full"}>
+      <canvas
+        ref={canvasRef}
+        style={{ display: "block" }}
+        aria-label="Basketball half court"
+        role="img"
+      />
+    </div>
+  );
+}

--- a/src/components/court/courtDimensions.ts
+++ b/src/components/court/courtDimensions.ts
@@ -1,0 +1,114 @@
+/**
+ * NBA half-court dimensions in feet.
+ * Origin (0, 0) is the top-left corner of the half court.
+ * The baseline is at y = COURT_HEIGHT (bottom edge, where the basket is).
+ *
+ * Reference: NBA official court specifications.
+ *   - Full court: 94ft × 50ft
+ *   - Half court: 47ft × 50ft
+ */
+
+// ---------------------------------------------------------------------------
+// Raw feet dimensions
+// ---------------------------------------------------------------------------
+
+/** Half-court length in feet (baseline to half-court line). */
+export const COURT_LENGTH_FT = 47;
+
+/** Court width in feet. */
+export const COURT_WIDTH_FT = 50;
+
+/**
+ * Aspect ratio: width / length.
+ * The canvas is wider than it is tall (landscape orientation for a half court
+ * viewed from behind the basket).
+ */
+export const COURT_ASPECT_RATIO = COURT_WIDTH_FT / COURT_LENGTH_FT; // ≈ 1.064
+
+// ---------------------------------------------------------------------------
+// Normalised (0–1) coordinates
+// All values are expressed as a fraction of the court's full dimensions so
+// that the canvas can be drawn at any pixel size.
+// x: 0 = left sideline,  1 = right sideline
+// y: 0 = half-court line, 1 = baseline (basket end)
+// ---------------------------------------------------------------------------
+
+/** Basket distance from baseline in feet. */
+const BASKET_FROM_BASELINE_FT = 5.25;
+
+/** Basket normalised y (measured from half-court line toward baseline). */
+export const BASKET_Y = 1 - BASKET_FROM_BASELINE_FT / COURT_LENGTH_FT;
+
+/** Basket normalised x (centre of court). */
+export const BASKET_X = 0.5;
+
+/** Basket radius in feet. */
+const BASKET_RADIUS_FT = 0.75;
+export const BASKET_RADIUS = BASKET_RADIUS_FT / COURT_WIDTH_FT;
+
+/** Backboard half-width in feet. */
+const BACKBOARD_HALF_WIDTH_FT = 3;
+export const BACKBOARD_HALF_WIDTH = BACKBOARD_HALF_WIDTH_FT / COURT_WIDTH_FT;
+
+/** Backboard distance from baseline in feet. */
+const BACKBOARD_FROM_BASELINE_FT = 4;
+export const BACKBOARD_Y = 1 - BACKBOARD_FROM_BASELINE_FT / COURT_LENGTH_FT;
+
+// ---------------------------------------------------------------------------
+// Paint / Free-throw lane
+// NBA lane: 16ft wide × 19ft deep (from baseline)
+// ---------------------------------------------------------------------------
+const LANE_WIDTH_FT = 16;
+const LANE_DEPTH_FT = 19;
+
+export const LANE_LEFT = (COURT_WIDTH_FT / 2 - LANE_WIDTH_FT / 2) / COURT_WIDTH_FT;
+export const LANE_RIGHT = (COURT_WIDTH_FT / 2 + LANE_WIDTH_FT / 2) / COURT_WIDTH_FT;
+export const LANE_TOP = 1 - LANE_DEPTH_FT / COURT_LENGTH_FT; // y = 0 is top (half-court)
+export const LANE_BOTTOM = 1; // baseline
+
+// ---------------------------------------------------------------------------
+// Free-throw line
+// ---------------------------------------------------------------------------
+/** Free-throw line is at the top of the lane box (19ft from baseline). */
+export const FREE_THROW_LINE_Y = LANE_TOP;
+
+// ---------------------------------------------------------------------------
+// Free-throw circle
+// NBA free-throw circle radius: 6ft
+// ---------------------------------------------------------------------------
+const FT_CIRCLE_RADIUS_FT = 6;
+export const FT_CIRCLE_RADIUS = FT_CIRCLE_RADIUS_FT / COURT_WIDTH_FT;
+export const FT_CIRCLE_CENTER_X = 0.5;
+export const FT_CIRCLE_CENTER_Y = FREE_THROW_LINE_Y;
+
+// ---------------------------------------------------------------------------
+// Three-point arc
+// NBA three-point line:
+//   - Corner three: 3ft from sideline, extends 14ft from baseline
+//   - Arc radius: 23.75ft from basket centre
+// ---------------------------------------------------------------------------
+const THREE_POINT_RADIUS_FT = 23.75;
+export const THREE_POINT_RADIUS = THREE_POINT_RADIUS_FT / COURT_WIDTH_FT;
+
+/** Distance of corner three line from baseline in feet. */
+const CORNER_THREE_DEPTH_FT = 14;
+export const CORNER_THREE_Y = 1 - CORNER_THREE_DEPTH_FT / COURT_LENGTH_FT;
+
+/** Corner three x positions (3ft from each sideline). */
+const CORNER_THREE_INSET_FT = 3;
+export const CORNER_THREE_LEFT_X = CORNER_THREE_INSET_FT / COURT_WIDTH_FT;
+export const CORNER_THREE_RIGHT_X = 1 - CORNER_THREE_INSET_FT / COURT_WIDTH_FT;
+
+// ---------------------------------------------------------------------------
+// Restricted area arc
+// NBA restricted arc radius: 4ft from basket centre
+// ---------------------------------------------------------------------------
+const RESTRICTED_RADIUS_FT = 4;
+export const RESTRICTED_RADIUS = RESTRICTED_RADIUS_FT / COURT_WIDTH_FT;
+
+// ---------------------------------------------------------------------------
+// Half-court circle
+// NBA centre circle radius: 6ft
+// ---------------------------------------------------------------------------
+const CENTRE_CIRCLE_RADIUS_FT = 6;
+export const CENTRE_CIRCLE_RADIUS = CENTRE_CIRCLE_RADIUS_FT / COURT_WIDTH_FT;


### PR DESCRIPTION
## Summary

- Adds `src/components/court/Court.tsx` — a React client component that renders an NBA half court on an HTML5 Canvas element
- Adds `src/components/court/courtDimensions.ts` — all NBA court dimensions as named constants (both feet and 0-1 normalised) for reuse by player/annotation components
- Wires the `Court` component into the play editor page (`/play/[id]`) so it renders in the central canvas area

## What's in the court

- Court boundary, half-court line, and half-centre-circle arc
- Paint (free-throw lane) with orange fill and white outline
- Free-throw line and full free-throw circle (solid upper half, dashed lower half per standard diagrams)
- Three-point arc with correct NBA corner-three straight segments (3ft from sideline, 14ft deep)
- Restricted-area arc (4ft radius from basket)
- Backboard line and basket/rim circle

## Technical notes

- Responsive via `ResizeObserver` — fills container width, height driven by the 50×47ft aspect ratio
- Renders at `devicePixelRatio` for crisp display on Retina screens
- Arcs are drawn in a feet-coordinate system (`ctx.save/scale`) to avoid ellipse distortion from the non-square canvas
- Exposes `courtToCanvas(normX, normY)` via an `onReady` callback so future player/annotation overlays can map 0-1 court coords to pixels without touching canvas internals

## Quality checks

- `npm run build` — passes
- `npm run lint` — no warnings or errors
- `npx tsc --noEmit` — no type errors

> Please squash-merge this PR.