### PR TITLE
Fix #51 #52: Draggable offensive and defensive player tokens on court

### DIFF
--- a/src/app/play/[id]/EditorCourtArea.tsx
+++ b/src/app/play/[id]/EditorCourtArea.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+/**
+ * EditorCourtArea — client component that renders the court with draggable players.
+ *
+ * Bootstraps a default play in the Zustand store (if none is loaded) and
+ * wires CourtWithPlayers to the selected scene.
+ */
+
+import { useEffect } from "react";
+import { useStore, createDefaultPlay, selectEditorScene } from "@/lib/store";
+import CourtWithPlayers from "@/components/players/CourtWithPlayers";
+
+export default function EditorCourtArea() {
+  const currentPlay = useStore((s) => s.currentPlay);
+  const setCurrentPlay = useStore((s) => s.setCurrentPlay);
+  const selectedSceneId = useStore((s) => s.selectedSceneId);
+  const setSelectedSceneId = useStore((s) => s.setSelectedSceneId);
+  const scene = useStore(selectEditorScene);
+
+  // Bootstrap a default play if the editor has no play loaded yet.
+  useEffect(() => {
+    if (!currentPlay) {
+      const play = createDefaultPlay();
+      setCurrentPlay(play);
+      setSelectedSceneId(play.scenes[0].id);
+    }
+  }, [currentPlay, setCurrentPlay, setSelectedSceneId]);
+
+  return (
+    <CourtWithPlayers
+      sceneId={selectedSceneId ?? scene?.id}
+      scene={scene}
+      className="w-full max-w-3xl"
+    />
+  );
+}

--- a/src/app/play/[id]/page.tsx
+++ b/src/app/play/[id]/page.tsx
@@ -1,4 +1,4 @@
-import Court from "@/components/court/Court";
+import EditorCourtArea from "./EditorCourtArea";
 
 interface PlayEditorPageProps {
   params: { id: string };
@@ -26,9 +26,9 @@ export default function PlayEditorPage({ params }: PlayEditorPageProps) {
         <aside className="flex w-16 flex-col items-center gap-3 border-r border-gray-200 bg-gray-50 py-4">
           <div className="text-xs text-gray-400">Tools</div>
         </aside>
-        {/* Court Canvas */}
+        {/* Court Canvas with draggable players */}
         <div className="flex flex-1 items-center justify-center overflow-auto bg-gray-100 p-4">
-          <Court className="w-full max-w-3xl" />
+          <EditorCourtArea />
         </div>
         {/* Play Info Panel */}
         <aside className="w-64 border-l border-gray-200 bg-white p-4">

--- a/src/components/players/CourtWithPlayers.tsx
+++ b/src/components/players/CourtWithPlayers.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+/**
+ * CourtWithPlayers — wraps the Court canvas and overlays draggable player tokens.
+ *
+ * Implements issues #51 and #52:
+ *   #51 — Draggable offensive players (O1–O5)
+ *   #52 — Draggable defensive players (X1–X5)
+ *
+ * Architecture:
+ *   - The Court canvas is rendered inside a relatively-positioned container.
+ *   - An absolutely-positioned SVG layer of the same dimensions is overlaid on top.
+ *   - Player tokens are SVG <g> elements positioned in CSS pixel coords.
+ *   - Normalised [0-1] court coords are used in the Zustand store; conversion
+ *     to/from CSS pixels is done via the courtToCanvas callback from Court.
+ *
+ * Default positions:
+ *   Offense — standard 5-out (perimeter) set:
+ *     O1 (PG) top of key, O2/O3 wings, O4/O5 corners
+ *   Defense — man-to-man mirroring:
+ *     X1–X5 shadow their offensive counterparts with a ~4ft sag
+ */
+
+import { useState, useCallback, useRef } from "react";
+import Court, { type CourtReadyPayload } from "@/components/court/Court";
+import PlayerToken from "./PlayerToken";
+import { useStore } from "@/lib/store";
+import type { Scene, PlayerState } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Default normalised court positions (y: 0 = half-court, 1 = baseline)
+// ---------------------------------------------------------------------------
+
+/**
+ * Offensive 5-out spacing defaults.
+ * Positions are (normX, normY) in court coordinate space [0-1].
+ */
+const OFFENSE_DEFAULTS: [number, number][] = [
+  [0.5, 0.35], // O1 — PG, top of key
+  [0.18, 0.48], // O2 — left wing
+  [0.82, 0.48], // O3 — right wing
+  [0.08, 0.75], // O4 — left corner
+  [0.92, 0.75], // O5 — right corner
+];
+
+/**
+ * Defensive defaults — slightly higher (sagging toward basket).
+ */
+const DEFENSE_DEFAULTS: [number, number][] = [
+  [0.5, 0.42],  // X1 — on ball
+  [0.22, 0.54], // X2
+  [0.78, 0.54], // X3
+  [0.14, 0.78], // X4
+  [0.86, 0.78], // X5
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normToPixel(
+  normX: number,
+  normY: number,
+  width: number,
+  height: number,
+): { x: number; y: number } {
+  return { x: normX * width, y: normY * height };
+}
+
+function pixelToNorm(
+  px: number,
+  py: number,
+  width: number,
+  height: number,
+): { x: number; y: number } {
+  return { x: px / width, y: py / height };
+}
+
+/** Create a default PlayerState array from normalised position defaults. */
+function defaultPlayers(
+  defaults: [number, number][],
+): PlayerState[] {
+  return defaults.map(([x, y], i) => ({
+    position: i + 1,
+    x,
+    y,
+    visible: true,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Local player position state (pixel coords) — derived from store / defaults
+// ---------------------------------------------------------------------------
+
+interface PixelPlayer {
+  position: number;
+  px: number;
+  py: number;
+  visible: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface CourtWithPlayersProps {
+  /** The id of the currently active scene, used to write to the store. */
+  sceneId?: string;
+  /** Optional scene to read player positions from. Falls back to defaults. */
+  scene?: Scene | null;
+  className?: string;
+}
+
+export default function CourtWithPlayers({ sceneId, scene, className }: CourtWithPlayersProps) {
+  const updatePlayerState = useStore((s) => s.updatePlayerState);
+
+  // Court layout reported by the Court canvas
+  const [courtSize, setCourtSize] = useState<{ width: number; height: number } | null>(null);
+
+  // Local pixel-position state for smooth dragging (avoids round-tripping through store on every mousemove)
+  const [offensePx, setOffensePx] = useState<PixelPlayer[] | null>(null);
+  const [defensePx, setDefensePx] = useState<PixelPlayer[] | null>(null);
+
+  // Track the last known court size for re-projection on resize
+  const courtSizeRef = useRef<{ width: number; height: number } | null>(null);
+
+  // -------------------------------------------------------------------------
+  // When the court canvas reports its size, initialise pixel positions
+  // -------------------------------------------------------------------------
+  const handleCourtReady = useCallback(
+    (payload: CourtReadyPayload) => {
+      const { width, height } = payload;
+      const prevSize = courtSizeRef.current;
+      courtSizeRef.current = { width, height };
+      setCourtSize({ width, height });
+
+      // If size changed (resize) but we already have pixel positions, re-project
+      if (prevSize && (prevSize.width !== width || prevSize.height !== height)) {
+        setOffensePx((prev) =>
+          prev
+            ? prev.map((p) => {
+                const norm = pixelToNorm(p.px, p.py, prevSize.width, prevSize.height);
+                const { x, y } = normToPixel(norm.x, norm.y, width, height);
+                return { ...p, px: x, py: y };
+              })
+            : null,
+        );
+        setDefensePx((prev) =>
+          prev
+            ? prev.map((p) => {
+                const norm = pixelToNorm(p.px, p.py, prevSize.width, prevSize.height);
+                const { x, y } = normToPixel(norm.x, norm.y, width, height);
+                return { ...p, px: x, py: y };
+              })
+            : null,
+        );
+        return;
+      }
+
+      // First render — project from store or defaults
+      if (!prevSize) {
+        const offenseStoreState = scene?.players.offense ?? defaultPlayers(OFFENSE_DEFAULTS);
+        const defenseStoreState = scene?.players.defense ?? defaultPlayers(DEFENSE_DEFAULTS);
+
+        setOffensePx(
+          offenseStoreState.map((p) => {
+            const { x, y } = normToPixel(p.x, p.y, width, height);
+            return { position: p.position, px: x, py: y, visible: p.visible };
+          }),
+        );
+        setDefensePx(
+          defenseStoreState.map((p) => {
+            const { x, y } = normToPixel(p.x, p.y, width, height);
+            return { position: p.position, px: x, py: y, visible: p.visible };
+          }),
+        );
+      }
+    },
+    [scene],
+  );
+
+  // -------------------------------------------------------------------------
+  // Drag handlers
+  // -------------------------------------------------------------------------
+
+  const handleOffenseDrag = useCallback((position: number, newCx: number, newCy: number) => {
+    setOffensePx((prev) =>
+      prev
+        ? prev.map((p) => (p.position === position ? { ...p, px: newCx, py: newCy } : p))
+        : prev,
+    );
+  }, []);
+
+  const handleOffenseDragEnd = useCallback(
+    (position: number, newCx: number, newCy: number) => {
+      setOffensePx((prev) =>
+        prev
+          ? prev.map((p) => (p.position === position ? { ...p, px: newCx, py: newCy } : p))
+          : prev,
+      );
+      if (sceneId && courtSizeRef.current) {
+        const { x, y } = pixelToNorm(newCx, newCy, courtSizeRef.current.width, courtSizeRef.current.height);
+        updatePlayerState(sceneId, "offense", { position, x, y, visible: true });
+      }
+    },
+    [sceneId, updatePlayerState],
+  );
+
+  const handleDefenseDrag = useCallback((position: number, newCx: number, newCy: number) => {
+    setDefensePx((prev) =>
+      prev
+        ? prev.map((p) => (p.position === position ? { ...p, px: newCx, py: newCy } : p))
+        : prev,
+    );
+  }, []);
+
+  const handleDefenseDragEnd = useCallback(
+    (position: number, newCx: number, newCy: number) => {
+      setDefensePx((prev) =>
+        prev
+          ? prev.map((p) => (p.position === position ? { ...p, px: newCx, py: newCy } : p))
+          : prev,
+      );
+      if (sceneId && courtSizeRef.current) {
+        const { x, y } = pixelToNorm(newCx, newCy, courtSizeRef.current.width, courtSizeRef.current.height);
+        updatePlayerState(sceneId, "defense", { position, x, y, visible: true });
+      }
+    },
+    [sceneId, updatePlayerState],
+  );
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  return (
+    <div className={`relative ${className ?? "w-full"}`}>
+      {/* Court canvas */}
+      <Court onReady={handleCourtReady} className="w-full" />
+
+      {/* SVG player overlay — same dimensions as the canvas */}
+      {courtSize && (
+        <svg
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: courtSize.width,
+            height: courtSize.height,
+            overflow: "visible",
+            pointerEvents: "none",
+          }}
+          viewBox={`0 0 ${courtSize.width} ${courtSize.height}`}
+          aria-hidden="true"
+        >
+          {/* Enable pointer events only on the tokens themselves */}
+          <g style={{ pointerEvents: "all" }}>
+            {/* Defensive players (rendered first = underneath offensive) */}
+            {defensePx
+              ?.filter((p) => p.visible)
+              .map((p) => (
+                <PlayerToken
+                  key={`defense-${p.position}`}
+                  side="defense"
+                  position={p.position}
+                  cx={p.px}
+                  cy={p.py}
+                  courtBounds={courtSize}
+                  onDrag={(x, y) => handleDefenseDrag(p.position, x, y)}
+                  onDragEnd={(x, y) => handleDefenseDragEnd(p.position, x, y)}
+                />
+              ))}
+
+            {/* Offensive players (rendered on top) */}
+            {offensePx
+              ?.filter((p) => p.visible)
+              .map((p) => (
+                <PlayerToken
+                  key={`offense-${p.position}`}
+                  side="offense"
+                  position={p.position}
+                  cx={p.px}
+                  cy={p.py}
+                  courtBounds={courtSize}
+                  onDrag={(x, y) => handleOffenseDrag(p.position, x, y)}
+                  onDragEnd={(x, y) => handleOffenseDragEnd(p.position, x, y)}
+                />
+              ))}
+          </g>
+        </svg>
+      )}
+    </div>
+  );
+}

--- a/src/components/players/PlayerToken.tsx
+++ b/src/components/players/PlayerToken.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+/**
+ * PlayerToken — a single draggable player circle rendered as an SVG element.
+ *
+ * Offensive players: filled solid circle (warm orange) with white position number.
+ * Defensive players: hollow circle with an X mark and position number.
+ *
+ * Props are expressed in *CSS pixels* relative to the court canvas so that the
+ * parent CourtWithPlayers can place them correctly.
+ */
+
+import { useRef, useCallback } from "react";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Radius of the player token in CSS pixels (independent of DPR). */
+const PLAYER_RADIUS = 18;
+
+const COLOR_OFFENSE_FILL = "#E07B39"; // warm orange (matches court paint)
+const COLOR_OFFENSE_STROKE = "#FFFFFF";
+const COLOR_DEFENSE_FILL = "#FFFFFF";
+const COLOR_DEFENSE_STROKE = "#1E3A5F"; // dark navy
+const COLOR_TEXT_OFFENSE = "#FFFFFF";
+const COLOR_TEXT_DEFENSE = "#1E3A5F";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PlayerTokenProps {
+  /** "offense" or "defense" */
+  side: "offense" | "defense";
+  /** 1-based position number */
+  position: number;
+  /** CSS pixel x position of the player centre within the court container */
+  cx: number;
+  /** CSS pixel y position of the player centre within the court container */
+  cy: number;
+  /** Called continuously as the player is dragged */
+  onDrag: (newCx: number, newCy: number) => void;
+  /** Called when drag ends, signals store should be updated */
+  onDragEnd: (newCx: number, newCy: number) => void;
+  /** Bounding box (in CSS px) to clamp drag inside the court */
+  courtBounds: { width: number; height: number };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function PlayerToken({
+  side,
+  position,
+  cx,
+  cy,
+  onDrag,
+  onDragEnd,
+  courtBounds,
+}: PlayerTokenProps) {
+  const isDragging = useRef(false);
+  const dragStart = useRef<{ mouseX: number; mouseY: number; playerCx: number; playerCy: number }>({
+    mouseX: 0,
+    mouseY: 0,
+    playerCx: 0,
+    playerCy: 0,
+  });
+
+  const clamp = useCallback(
+    (x: number, y: number): { x: number; y: number } => ({
+      x: Math.max(PLAYER_RADIUS, Math.min(courtBounds.width - PLAYER_RADIUS, x)),
+      y: Math.max(PLAYER_RADIUS, Math.min(courtBounds.height - PLAYER_RADIUS, y)),
+    }),
+    [courtBounds],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isDragging.current) return;
+      const dx = e.clientX - dragStart.current.mouseX;
+      const dy = e.clientY - dragStart.current.mouseY;
+      const { x, y } = clamp(dragStart.current.playerCx + dx, dragStart.current.playerCy + dy);
+      onDrag(x, y);
+    },
+    [clamp, onDrag],
+  );
+
+  const handleMouseUp = useCallback(
+    (e: MouseEvent) => {
+      if (!isDragging.current) return;
+      isDragging.current = false;
+      const dx = e.clientX - dragStart.current.mouseX;
+      const dy = e.clientY - dragStart.current.mouseY;
+      const { x, y } = clamp(dragStart.current.playerCx + dx, dragStart.current.playerCy + dy);
+      onDragEnd(x, y);
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    },
+    [clamp, onDragEnd, handleMouseMove],
+  );
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<SVGGElement>) => {
+      e.preventDefault();
+      isDragging.current = true;
+      dragStart.current = { mouseX: e.clientX, mouseY: e.clientY, playerCx: cx, playerCy: cy };
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
+    },
+    [cx, cy, handleMouseMove, handleMouseUp],
+  );
+
+  // Touch support
+  const handleTouchMove = useCallback(
+    (e: TouchEvent) => {
+      if (!isDragging.current) return;
+      e.preventDefault();
+      const touch = e.touches[0];
+      if (!touch) return;
+      const dx = touch.clientX - dragStart.current.mouseX;
+      const dy = touch.clientY - dragStart.current.mouseY;
+      const { x, y } = clamp(dragStart.current.playerCx + dx, dragStart.current.playerCy + dy);
+      onDrag(x, y);
+    },
+    [clamp, onDrag],
+  );
+
+  const handleTouchEnd = useCallback(
+    (e: TouchEvent) => {
+      if (!isDragging.current) return;
+      isDragging.current = false;
+      const touch = e.changedTouches[0];
+      if (touch) {
+        const dx = touch.clientX - dragStart.current.mouseX;
+        const dy = touch.clientY - dragStart.current.mouseY;
+        const { x, y } = clamp(dragStart.current.playerCx + dx, dragStart.current.playerCy + dy);
+        onDragEnd(x, y);
+      }
+      window.removeEventListener("touchmove", handleTouchMove);
+      window.removeEventListener("touchend", handleTouchEnd);
+    },
+    [clamp, onDragEnd, handleTouchMove],
+  );
+
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent<SVGGElement>) => {
+      const touch = e.touches[0];
+      if (!touch) return;
+      isDragging.current = true;
+      dragStart.current = {
+        mouseX: touch.clientX,
+        mouseY: touch.clientY,
+        playerCx: cx,
+        playerCy: cy,
+      };
+      window.addEventListener("touchmove", handleTouchMove, { passive: false });
+      window.addEventListener("touchend", handleTouchEnd);
+    },
+    [cx, cy, handleTouchMove, handleTouchEnd],
+  );
+
+  const isOffense = side === "offense";
+  const fillColor = isOffense ? COLOR_OFFENSE_FILL : COLOR_DEFENSE_FILL;
+  const strokeColor = isOffense ? COLOR_OFFENSE_STROKE : COLOR_DEFENSE_STROKE;
+  const textColor = isOffense ? COLOR_TEXT_OFFENSE : COLOR_TEXT_DEFENSE;
+  const strokeWidth = isOffense ? 2 : 2.5;
+  const label = isOffense ? String(position) : `X${position}`;
+  const fontSize = isOffense ? 11 : 9;
+
+  return (
+    <g
+      transform={`translate(${cx}, ${cy})`}
+      onMouseDown={handleMouseDown}
+      onTouchStart={handleTouchStart}
+      style={{ cursor: "grab" }}
+      role="button"
+      aria-label={`${isOffense ? "Offensive" : "Defensive"} player ${position}`}
+    >
+      {/* Drop shadow */}
+      <circle
+        r={PLAYER_RADIUS}
+        cx={1}
+        cy={2}
+        fill="rgba(0,0,0,0.25)"
+      />
+      {/* Main circle */}
+      <circle
+        r={PLAYER_RADIUS}
+        fill={fillColor}
+        stroke={strokeColor}
+        strokeWidth={strokeWidth}
+      />
+      {/* Defensive X lines */}
+      {!isOffense && (
+        <>
+          <line
+            x1={-7}
+            y1={-7}
+            x2={7}
+            y2={7}
+            stroke={COLOR_DEFENSE_STROKE}
+            strokeWidth={2.5}
+            strokeLinecap="round"
+          />
+          <line
+            x1={7}
+            y1={-7}
+            x2={-7}
+            y2={7}
+            stroke={COLOR_DEFENSE_STROKE}
+            strokeWidth={2.5}
+            strokeLinecap="round"
+          />
+        </>
+      )}
+      {/* Position label */}
+      <text
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill={textColor}
+        fontSize={fontSize}
+        fontWeight="700"
+        fontFamily="system-ui, sans-serif"
+        dy={isOffense ? 0 : -9}
+        style={{ pointerEvents: "none", userSelect: "none" }}
+      >
+        {label}
+      </text>
+    </g>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `PlayerToken` SVG component: draggable circle token for a single player. Offensive players (O1–O5) render as filled orange circles with white position numbers; defensive players (X1–X5) render as hollow navy circles with an X overlay and position number.
- Adds `CourtWithPlayers` component: absolutely-positions an SVG layer over the Court canvas. On first render it initialises player positions from the active Zustand scene (or from sensible 5-out offense / man-to-man defense defaults). On drag-end, normalised [0-1] court coordinates are written back to the store via `updatePlayerState`. On window resize the player positions re-project correctly.
- Adds `EditorCourtArea` (client component): bootstraps a default play if none is loaded, then renders `CourtWithPlayers` wired to the active scene.
- Swaps the bare `Court` in `src/app/play/[id]/page.tsx` for `EditorCourtArea`.

Closes #51
Closes #52

## Test plan

- [ ] Navigate to `/play/test` — court renders with 5 orange offensive and 5 navy/white defensive tokens at default positions.
- [ ] Drag any offensive token around the court; it stays within the court boundary.
- [ ] Drag any defensive token; same boundary behaviour.
- [ ] Resize the browser window; tokens remain proportionally positioned.
- [ ] Verify build passes: `npm run build && npm run lint && npx tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)