### PR TITLE
Fix #56 + #57: Drawing tools panel and player movement annotation

### DIFF
--- a/src/app/play/[id]/page.tsx
+++ b/src/app/play/[id]/page.tsx
@@ -1,4 +1,5 @@
 import EditorCourtArea from "./EditorCourtArea";
+import DrawingToolsPanel from "@/components/editor/DrawingToolsPanel";
 
 interface PlayEditorPageProps {
   params: { id: string };
@@ -23,9 +24,7 @@ export default function PlayEditorPage({ params }: PlayEditorPageProps) {
       </header>
       <div className="flex flex-1 overflow-hidden">
         {/* Tools Panel */}
-        <aside className="flex w-16 flex-col items-center gap-3 border-r border-gray-200 bg-gray-50 py-4">
-          <div className="text-xs text-gray-400">Tools</div>
-        </aside>
+        <DrawingToolsPanel />
         {/* Court Canvas with draggable players */}
         <div className="flex flex-1 items-center justify-center overflow-auto bg-gray-100 p-4">
           <EditorCourtArea />

--- a/src/components/annotations/AnnotationLayer.tsx
+++ b/src/components/annotations/AnnotationLayer.tsx
@@ -1,0 +1,583 @@
+"use client";
+
+/**
+ * AnnotationLayer — SVG overlay that handles annotation drawing interactions
+ * and renders all existing annotations for the active scene / timing step.
+ *
+ * Implements issue #57: Player movement annotation (solid arrow line).
+ *
+ * Architecture:
+ *   - Rendered as an absolutely-positioned SVG on top of CourtWithPlayers.
+ *   - When a drawing tool is active, pointer events are captured by this layer.
+ *   - When "select" is active, pointer events fall through to player tokens below.
+ *   - The layer tracks an in-progress line (from mousedown → mouseup), then
+ *     commits the resulting Annotation to the Zustand store via addAnnotation.
+ *
+ * Coordinate system:
+ *   - The `width`/`height` props are the CSS pixel dimensions of the court.
+ *   - Normalised [0-1] coords are stored in the Zustand store.
+ *   - SVG renders in CSS-pixel space (same as CourtWithPlayers overlay).
+ *
+ * Snap-to-player:
+ *   - When starting or ending a stroke within SNAP_RADIUS px of a player, the
+ *     annotation endpoint is snapped to that player and a fromPlayer/toPlayer
+ *     reference is stored.
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useStore, selectEditorScene, selectAllAnnotations } from "@/lib/store";
+import type { DrawingTool } from "@/lib/store";
+import type { Annotation, Point } from "@/lib/types";
+import { TOOL_CURSOR } from "@/components/editor/DrawingToolsPanel";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Pixel distance within which a stroke endpoint snaps to a player token. */
+const SNAP_RADIUS = 28;
+
+/** Radius used to draw a snap indicator ring. */
+const SNAP_RING_RADIUS = 24;
+
+// ---------------------------------------------------------------------------
+// Rendering helpers per annotation type
+// ---------------------------------------------------------------------------
+
+/** Compute an arrowhead polygon points string given a line endpoint and direction. */
+function arrowHead(
+  x2: number,
+  y2: number,
+  x1: number,
+  y1: number,
+  size: number = 12,
+): string {
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const len = Math.sqrt(dx * dx + dy * dy);
+  if (len < 1) return "";
+  const ux = dx / len;
+  const uy = dy / len;
+  // Perpendicular
+  const px = -uy;
+  const py = ux;
+  const tipX = x2;
+  const tipY = y2;
+  const baseX = x2 - ux * size;
+  const baseY = y2 - uy * size;
+  const w = size * 0.45;
+  return `${tipX},${tipY} ${baseX + px * w},${baseY + py * w} ${baseX - px * w},${baseY - py * w}`;
+}
+
+interface RenderedAnnotationProps {
+  ann: Annotation;
+  selected: boolean;
+  onSelect: (id: string) => void;
+}
+
+function RenderedAnnotation({ ann, selected, onSelect }: RenderedAnnotationProps) {
+  const { from, to, type } = ann;
+  const hitStyle: React.CSSProperties = { cursor: "pointer", pointerEvents: "stroke" };
+
+  const headPoints = arrowHead(to.x, to.y, from.x, from.y);
+  const selectRing = selected ? (
+    <rect
+      x={Math.min(from.x, to.x) - 6}
+      y={Math.min(from.y, to.y) - 6}
+      width={Math.abs(to.x - from.x) + 12}
+      height={Math.abs(to.y - from.y) + 12}
+      rx={4}
+      fill="none"
+      stroke="#3B82F6"
+      strokeWidth={1.5}
+      strokeDasharray="4 2"
+      pointerEvents="none"
+    />
+  ) : null;
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onSelect(ann.id);
+  };
+
+  if (type === "movement") {
+    return (
+      <g onClick={handleClick} style={hitStyle}>
+        {selectRing}
+        {/* Invisible wide hit-area */}
+        <line
+          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+          stroke="transparent" strokeWidth={14}
+        />
+        <line
+          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+          stroke="#1E3A5F"
+          strokeWidth={2.5}
+          strokeLinecap="round"
+        />
+        {headPoints && (
+          <polygon points={headPoints} fill="#1E3A5F" />
+        )}
+      </g>
+    );
+  }
+
+  if (type === "dribble") {
+    // Build zigzag path
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const zigCount = Math.max(2, Math.round(len / 18));
+    const pts: string[] = [];
+    for (let i = 0; i <= zigCount; i++) {
+      const t = i / zigCount;
+      const mx = from.x + dx * t;
+      const my = from.y + dy * t;
+      // Perpendicular offset alternates
+      const perp = i % 2 === 0 ? 6 : -6;
+      const px2 = -dy / len * perp;
+      const py2 = dx / len * perp;
+      pts.push(`${mx + px2},${my + py2}`);
+    }
+    const d = `M ${pts.join(" L ")}`;
+    return (
+      <g onClick={handleClick} style={hitStyle}>
+        {selectRing}
+        <path d={d} stroke="transparent" strokeWidth={14} fill="none" />
+        <path
+          d={d}
+          stroke="#1E3A5F"
+          strokeWidth={2.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+        {headPoints && <polygon points={headPoints} fill="#1E3A5F" />}
+      </g>
+    );
+  }
+
+  if (type === "pass") {
+    // Straight line with solid triangle tip — rendered slightly thinner / different colour
+    return (
+      <g onClick={handleClick} style={hitStyle}>
+        {selectRing}
+        <line
+          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+          stroke="transparent" strokeWidth={14}
+        />
+        <line
+          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+          stroke="#059669"
+          strokeWidth={2}
+          strokeLinecap="round"
+        />
+        {headPoints && <polygon points={headPoints} fill="#059669" />}
+      </g>
+    );
+  }
+
+  if (type === "screen") {
+    // A line with a perpendicular bar at the end (like a comb)
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const ux = len > 0 ? dx / len : 1;
+    const uy = len > 0 ? dy / len : 0;
+    const perp = { x: -uy * 10, y: ux * 10 };
+    return (
+      <g onClick={handleClick} style={hitStyle}>
+        {selectRing}
+        <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke="transparent" strokeWidth={14} />
+        <line
+          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+          stroke="#7C3AED" strokeWidth={2.5} strokeLinecap="round"
+        />
+        {/* Perpendicular bar */}
+        <line
+          x1={to.x + perp.x} y1={to.y + perp.y}
+          x2={to.x - perp.x} y2={to.y - perp.y}
+          stroke="#7C3AED" strokeWidth={3} strokeLinecap="round"
+        />
+      </g>
+    );
+  }
+
+  if (type === "cut") {
+    return (
+      <g onClick={handleClick} style={hitStyle}>
+        {selectRing}
+        <line
+          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+          stroke="transparent" strokeWidth={14}
+        />
+        <line
+          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+          stroke="#DC2626"
+          strokeWidth={2.5}
+          strokeLinecap="round"
+          strokeDasharray="7 5"
+        />
+        {headPoints && <polygon points={headPoints} fill="#DC2626" />}
+      </g>
+    );
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// In-progress (preview) annotation
+// ---------------------------------------------------------------------------
+
+function PreviewAnnotation({
+  tool,
+  from,
+  to,
+}: {
+  tool: DrawingTool;
+  from: Point;
+  to: Point;
+}) {
+  const headPoints = arrowHead(to.x, to.y, from.x, from.y);
+
+  if (tool === "movement") {
+    return (
+      <g pointerEvents="none" opacity={0.7}>
+        <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke="#1E3A5F" strokeWidth={2.5} strokeLinecap="round" strokeDasharray="5 3" />
+        {headPoints && <polygon points={headPoints} fill="#1E3A5F" opacity={0.8} />}
+      </g>
+    );
+  }
+
+  if (tool === "dribble") {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const zigCount = Math.max(2, Math.round(len / 18));
+    const pts: string[] = [];
+    for (let i = 0; i <= zigCount; i++) {
+      const t = i / zigCount;
+      const mx = from.x + dx * t;
+      const my = from.y + dy * t;
+      const perp = i % 2 === 0 ? 6 : -6;
+      const px2 = len > 0 ? -dy / len * perp : 0;
+      const py2 = len > 0 ? dx / len * perp : 0;
+      pts.push(`${mx + px2},${my + py2}`);
+    }
+    const d = `M ${pts.join(" L ")}`;
+    return (
+      <g pointerEvents="none" opacity={0.7}>
+        <path d={d} stroke="#1E3A5F" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" fill="none" strokeDasharray="5 3" />
+        {headPoints && <polygon points={headPoints} fill="#1E3A5F" opacity={0.8} />}
+      </g>
+    );
+  }
+
+  if (tool === "pass") {
+    return (
+      <g pointerEvents="none" opacity={0.7}>
+        <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke="#059669" strokeWidth={2} strokeLinecap="round" strokeDasharray="5 3" />
+        {headPoints && <polygon points={headPoints} fill="#059669" opacity={0.8} />}
+      </g>
+    );
+  }
+
+  if (tool === "screen") {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const ux = len > 0 ? dx / len : 1;
+    const uy = len > 0 ? dy / len : 0;
+    const perp = { x: -uy * 10, y: ux * 10 };
+    return (
+      <g pointerEvents="none" opacity={0.7}>
+        <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke="#7C3AED" strokeWidth={2.5} strokeLinecap="round" />
+        <line x1={to.x + perp.x} y1={to.y + perp.y} x2={to.x - perp.x} y2={to.y - perp.y} stroke="#7C3AED" strokeWidth={3} strokeLinecap="round" />
+      </g>
+    );
+  }
+
+  if (tool === "cut") {
+    return (
+      <g pointerEvents="none" opacity={0.7}>
+        <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke="#DC2626" strokeWidth={2.5} strokeLinecap="round" strokeDasharray="7 5" />
+        {headPoints && <polygon points={headPoints} fill="#DC2626" opacity={0.8} />}
+      </g>
+    );
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Player snap data (passed in from parent)
+// ---------------------------------------------------------------------------
+
+export interface SnapPlayer {
+  px: number;
+  py: number;
+  side: "offense" | "defense";
+  position: number;
+}
+
+function findNearestPlayer(
+  x: number,
+  y: number,
+  players: SnapPlayer[],
+): SnapPlayer | null {
+  let nearest: SnapPlayer | null = null;
+  let minDist = SNAP_RADIUS;
+  for (const p of players) {
+    const dx = x - p.px;
+    const dy = y - p.py;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist < minDist) {
+      minDist = dist;
+      nearest = p;
+    }
+  }
+  return nearest;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface AnnotationLayerProps {
+  /** CSS pixel width of the court canvas. */
+  width: number;
+  /** CSS pixel height of the court canvas. */
+  height: number;
+  /** The scene ID currently being edited. */
+  sceneId: string | null;
+  /** Player positions for snap detection. */
+  players: SnapPlayer[];
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function AnnotationLayer({
+  width,
+  height,
+  sceneId,
+  players,
+}: AnnotationLayerProps) {
+  const selectedTool = useStore((s) => s.selectedTool);
+  const selectedTimingStep = useStore((s) => s.selectedTimingStep);
+  const selectedAnnotationId = useStore((s) => s.selectedAnnotationId);
+  const setSelectedAnnotationId = useStore((s) => s.setSelectedAnnotationId);
+  const addAnnotation = useStore((s) => s.addAnnotation);
+  const removeAnnotation = useStore((s) => s.removeAnnotation);
+  const scene = useStore(selectEditorScene);
+  const annotations = selectAllAnnotations(scene);
+
+  // In-progress stroke state
+  const [drawing, setDrawing] = useState<{ from: Point; to: Point } | null>(null);
+  const drawingRef = useRef<{ from: Point; to: Point } | null>(null);
+
+  // Snap highlight — player near cursor
+  const [snapTarget, setSnapTarget] = useState<SnapPlayer | null>(null);
+
+  const isDrawingTool = selectedTool !== "select";
+
+  // Get SVG-local coordinates from a mouse event
+  const svgRef = useRef<SVGSVGElement>(null);
+  const getSVGCoords = useCallback((e: React.MouseEvent | MouseEvent): Point => {
+    const svg = svgRef.current;
+    if (!svg) return { x: 0, y: 0 };
+    const rect = svg.getBoundingClientRect();
+    return {
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    };
+  }, []);
+
+  // Handle annotation selection / eraser click on background
+  const handleSVGClick = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      if (selectedTool === "select") {
+        // Deselect if clicking background
+        if (e.target === svgRef.current) {
+          setSelectedAnnotationId(null);
+        }
+      }
+    },
+    [selectedTool, setSelectedAnnotationId],
+  );
+
+  // Keyboard: Delete/Backspace removes selected annotation
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Delete" || e.key === "Backspace") {
+        const tag = (e.target as HTMLElement).tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+        if (selectedAnnotationId && sceneId) {
+          removeAnnotation(sceneId, selectedAnnotationId);
+        }
+      }
+    },
+    [selectedAnnotationId, sceneId, removeAnnotation],
+  );
+
+  // Register keyboard listener for Delete/Backspace
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Mouse down — start drawing
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      if (!isDrawingTool || selectedTool === "eraser") return;
+      e.preventDefault();
+      const pt = getSVGCoords(e);
+      const nearest = findNearestPlayer(pt.x, pt.y, players);
+      const from: Point = nearest ? { x: nearest.px, y: nearest.py } : pt;
+      const stroke = { from, to: from };
+      setDrawing(stroke);
+      drawingRef.current = stroke;
+      setSnapTarget(null);
+    },
+    [isDrawingTool, selectedTool, getSVGCoords, players],
+  );
+
+  // Mouse move — update preview
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      const pt = getSVGCoords(e);
+      const nearest = findNearestPlayer(pt.x, pt.y, players);
+      setSnapTarget(nearest);
+
+      if (!drawingRef.current) return;
+      const to: Point = nearest ? { x: nearest.px, y: nearest.py } : pt;
+      const next = { ...drawingRef.current, to };
+      drawingRef.current = next;
+      setDrawing(next);
+    },
+    [getSVGCoords, players],
+  );
+
+  // Mouse up — commit annotation
+  const handleMouseUp = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      if (!drawingRef.current || !sceneId) {
+        setDrawing(null);
+        drawingRef.current = null;
+        return;
+      }
+      const { from } = drawingRef.current;
+      const pt = getSVGCoords(e);
+      const nearest = findNearestPlayer(pt.x, pt.y, players);
+      const to: Point = nearest ? { x: nearest.px, y: nearest.py } : pt;
+
+      // Ignore tiny strokes (accidental clicks)
+      const dx = to.x - from.x;
+      const dy = to.y - from.y;
+      if (Math.sqrt(dx * dx + dy * dy) > 8) {
+        const fromNearest = findNearestPlayer(from.x, from.y, players);
+        const annotation: Annotation = {
+          id: crypto.randomUUID(),
+          type: selectedTool as Annotation["type"],
+          from,
+          to,
+          fromPlayer: fromNearest
+            ? { side: fromNearest.side, position: fromNearest.position }
+            : null,
+          toPlayer: nearest
+            ? { side: nearest.side, position: nearest.position }
+            : null,
+          controlPoints: [],
+        };
+        addAnnotation(sceneId, selectedTimingStep, annotation);
+        setSelectedAnnotationId(annotation.id);
+      }
+
+      setDrawing(null);
+      drawingRef.current = null;
+      setSnapTarget(null);
+    },
+    [
+      sceneId,
+      selectedTool,
+      selectedTimingStep,
+      getSVGCoords,
+      players,
+      addAnnotation,
+      setSelectedAnnotationId,
+    ],
+  );
+
+  // Handle eraser click on annotation
+  const handleAnnotationSelect = useCallback(
+    (id: string) => {
+      if (selectedTool === "eraser") {
+        if (sceneId) removeAnnotation(sceneId, id);
+      } else {
+        setSelectedAnnotationId(id);
+      }
+    },
+    [selectedTool, sceneId, removeAnnotation, setSelectedAnnotationId],
+  );
+
+  const cursor = TOOL_CURSOR[selectedTool];
+
+  return (
+    <svg
+      ref={svgRef}
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width,
+        height,
+        overflow: "visible",
+        cursor,
+        // Only capture events when a drawing tool is active
+        pointerEvents: isDrawingTool ? "all" : "none",
+      }}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-label="Annotation drawing layer"
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onClick={handleSVGClick}
+    >
+      {/* Existing annotations */}
+      {annotations.map((ann) => (
+        <RenderedAnnotation
+          key={ann.id}
+          ann={ann}
+          selected={selectedAnnotationId === ann.id}
+          onSelect={handleAnnotationSelect}
+        />
+      ))}
+
+      {/* Snap target ring */}
+      {snapTarget && isDrawingTool && (
+        <circle
+          cx={snapTarget.px}
+          cy={snapTarget.py}
+          r={SNAP_RING_RADIUS}
+          fill="none"
+          stroke="#3B82F6"
+          strokeWidth={1.5}
+          strokeDasharray="4 3"
+          pointerEvents="none"
+          opacity={0.7}
+        />
+      )}
+
+      {/* In-progress preview */}
+      {drawing && (
+        <PreviewAnnotation
+          tool={selectedTool}
+          from={drawing.from}
+          to={drawing.to}
+        />
+      )}
+    </svg>
+  );
+}

--- a/src/components/editor/DrawingToolsPanel.tsx
+++ b/src/components/editor/DrawingToolsPanel.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+/**
+ * DrawingToolsPanel — left-side toolbar for selecting drawing tools.
+ *
+ * Implements issue #56: Drawing tools panel UI.
+ *
+ * Tools:
+ *   Select / Move  (keyboard: V or Escape)
+ *   Movement       (keyboard: M) — solid arrow line
+ *   Dribble        (keyboard: D) — wavy/zigzag line
+ *   Pass           (keyboard: P) — line with triangle tip
+ *   Screen         (keyboard: S) — perpendicular line
+ *   Cut            (keyboard: C) — dashed arrow line
+ *   Eraser         (keyboard: E) — remove annotations
+ */
+
+import { useEffect, useCallback } from "react";
+import { useStore } from "@/lib/store";
+import type { DrawingTool } from "@/lib/store";
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+interface ToolDef {
+  id: DrawingTool;
+  label: string;
+  shortcut: string;
+  /** SVG icon content rendered inside a 28×28 viewBox */
+  Icon: React.FC<{ active: boolean }>;
+}
+
+// Shared icon colours
+const ACTIVE_COLOR = "#3B82F6"; // blue-500
+const IDLE_COLOR = "#6B7280";   // gray-500
+
+/** Select / Move tool icon (arrow cursor shape) */
+function SelectIcon({ active }: { active: boolean }) {
+  const c = active ? ACTIVE_COLOR : IDLE_COLOR;
+  return (
+    <svg viewBox="0 0 28 28" width={22} height={22} aria-hidden="true">
+      <path
+        d="M6 4 L6 20 L10 16 L14 24 L16 23 L12 15 L18 15 Z"
+        fill={c}
+        stroke={c}
+        strokeWidth={0.5}
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+/** Movement tool icon (solid arrow line) */
+function MovementIcon({ active }: { active: boolean }) {
+  const c = active ? ACTIVE_COLOR : IDLE_COLOR;
+  return (
+    <svg viewBox="0 0 28 28" width={22} height={22} aria-hidden="true">
+      <line x1="4" y1="24" x2="22" y2="6" stroke={c} strokeWidth={2.5} strokeLinecap="round" />
+      <polygon points="22,6 14,8 20,14" fill={c} />
+    </svg>
+  );
+}
+
+/** Dribble tool icon (wavy/zigzag arrow) */
+function DribbleIcon({ active }: { active: boolean }) {
+  const c = active ? ACTIVE_COLOR : IDLE_COLOR;
+  return (
+    <svg viewBox="0 0 28 28" width={22} height={22} aria-hidden="true">
+      <path
+        d="M4 22 Q7 16 10 19 Q13 22 16 16 Q19 10 22 6"
+        fill="none"
+        stroke={c}
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <polygon points="22,6 15,9 19,14" fill={c} />
+    </svg>
+  );
+}
+
+/** Pass tool icon (straight line with solid arrowhead) */
+function PassIcon({ active }: { active: boolean }) {
+  const c = active ? ACTIVE_COLOR : IDLE_COLOR;
+  return (
+    <svg viewBox="0 0 28 28" width={22} height={22} aria-hidden="true">
+      <line x1="4" y1="22" x2="22" y2="6" stroke={c} strokeWidth={2} strokeLinecap="round" />
+      {/* Filled equilateral triangle at tip */}
+      <polygon points="22,6 14,9 19,15" fill={c} />
+    </svg>
+  );
+}
+
+/** Screen / Pick tool icon (perpendicular line = L-shape) */
+function ScreenIcon({ active }: { active: boolean }) {
+  const c = active ? ACTIVE_COLOR : IDLE_COLOR;
+  return (
+    <svg viewBox="0 0 28 28" width={22} height={22} aria-hidden="true">
+      {/* Vertical bar of the screen */}
+      <line x1="14" y1="8" x2="14" y2="22" stroke={c} strokeWidth={3} strokeLinecap="round" />
+      {/* Horizontal bar of the screen */}
+      <line x1="8" y1="8" x2="20" y2="8" stroke={c} strokeWidth={3} strokeLinecap="round" />
+      {/* Arrow showing player path */}
+      <line x1="6" y1="22" x2="14" y2="22" stroke={c} strokeWidth={2} strokeLinecap="round" strokeDasharray="2 2" />
+    </svg>
+  );
+}
+
+/** Cut tool icon (dashed arrow line) */
+function CutIcon({ active }: { active: boolean }) {
+  const c = active ? ACTIVE_COLOR : IDLE_COLOR;
+  return (
+    <svg viewBox="0 0 28 28" width={22} height={22} aria-hidden="true">
+      <line
+        x1="4"
+        y1="22"
+        x2="20"
+        y2="6"
+        stroke={c}
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        strokeDasharray="4 3"
+      />
+      <polygon points="22,6 15,9 19,14" fill={c} />
+    </svg>
+  );
+}
+
+/** Eraser tool icon */
+function EraserIcon({ active }: { active: boolean }) {
+  const c = active ? ACTIVE_COLOR : IDLE_COLOR;
+  return (
+    <svg viewBox="0 0 28 28" width={22} height={22} aria-hidden="true">
+      <rect
+        x="5"
+        y="14"
+        width="18"
+        height="10"
+        rx="2"
+        fill="none"
+        stroke={c}
+        strokeWidth={2}
+      />
+      <line x1="5" y1="19" x2="23" y2="19" stroke={c} strokeWidth={1.5} />
+      <line x1="12" y1="14" x2="8" y2="5" stroke={c} strokeWidth={2} strokeLinecap="round" />
+      <line x1="16" y1="14" x2="20" y2="5" stroke={c} strokeWidth={2} strokeLinecap="round" />
+    </svg>
+  );
+}
+
+const TOOLS: ToolDef[] = [
+  { id: "select",   label: "Select",   shortcut: "V", Icon: SelectIcon   },
+  { id: "movement", label: "Move",     shortcut: "M", Icon: MovementIcon },
+  { id: "dribble",  label: "Dribble",  shortcut: "D", Icon: DribbleIcon  },
+  { id: "pass",     label: "Pass",     shortcut: "P", Icon: PassIcon     },
+  { id: "screen",   label: "Screen",   shortcut: "S", Icon: ScreenIcon   },
+  { id: "cut",      label: "Cut",      shortcut: "C", Icon: CutIcon      },
+  { id: "eraser",   label: "Eraser",   shortcut: "E", Icon: EraserIcon   },
+];
+
+/** Map keyboard key → DrawingTool (lower-cased) */
+const KEY_MAP: Record<string, DrawingTool> = {
+  v: "select",
+  escape: "select",
+  m: "movement",
+  d: "dribble",
+  p: "pass",
+  s: "screen",
+  c: "cut",
+  e: "eraser",
+};
+
+/** CSS cursor per tool */
+export const TOOL_CURSOR: Record<DrawingTool, string> = {
+  select:   "default",
+  movement: "crosshair",
+  dribble:  "crosshair",
+  pass:     "crosshair",
+  screen:   "crosshair",
+  cut:      "crosshair",
+  eraser:   "cell",
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function DrawingToolsPanel() {
+  const selectedTool = useStore((s) => s.selectedTool);
+  const setSelectedTool = useStore((s) => s.setSelectedTool);
+
+  // Keyboard shortcuts
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      // Ignore when typing in an input / textarea
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+
+      const tool = KEY_MAP[e.key.toLowerCase()];
+      if (tool) {
+        e.preventDefault();
+        setSelectedTool(tool);
+      }
+    },
+    [setSelectedTool],
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  return (
+    <aside
+      className="flex w-14 flex-col items-center gap-1 border-r border-gray-200 bg-gray-50 py-3"
+      aria-label="Drawing tools"
+    >
+      <span className="mb-1 text-[10px] font-medium uppercase tracking-widest text-gray-400">
+        Tools
+      </span>
+
+      {TOOLS.map(({ id, label, shortcut, Icon }) => {
+        const active = selectedTool === id;
+        return (
+          <button
+            key={id}
+            onClick={() => setSelectedTool(id)}
+            title={`${label} (${shortcut})`}
+            aria-label={label}
+            aria-pressed={active}
+            className={[
+              "flex w-10 flex-col items-center justify-center rounded-lg py-2 transition-colors",
+              active
+                ? "bg-blue-100 text-blue-600 shadow-inner"
+                : "text-gray-500 hover:bg-gray-200 hover:text-gray-700",
+            ].join(" ")}
+          >
+            <Icon active={active} />
+            <span className="mt-0.5 text-[9px] leading-none">{shortcut}</span>
+          </button>
+        );
+      })}
+    </aside>
+  );
+}

--- a/src/components/players/CourtWithPlayers.tsx
+++ b/src/components/players/CourtWithPlayers.tsx
@@ -33,6 +33,7 @@ import { useState, useCallback, useRef } from "react";
 import Court, { type CourtReadyPayload } from "@/components/court/Court";
 import PlayerToken from "./PlayerToken";
 import BallToken, { type NearbyPlayer, DETACH_RADIUS } from "./BallToken";
+import AnnotationLayer from "@/components/annotations/AnnotationLayer";
 import { useStore } from "@/lib/store";
 import type { Scene, PlayerState, BallState } from "@/lib/types";
 
@@ -450,6 +451,18 @@ export default function CourtWithPlayers({ sceneId, scene, className }: CourtWit
             )}
           </g>
         </svg>
+      )}
+
+      {/* Annotation drawing layer — sits above the player SVG so pointer events
+          can be captured by the active drawing tool without interfering with
+          player dragging when the select tool is active. */}
+      {courtSize && (
+        <AnnotationLayer
+          width={courtSize.width}
+          height={courtSize.height}
+          sceneId={sceneId ?? null}
+          players={allPlayers}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds `DrawingToolsPanel` — a left-side vertical toolbar with 7 tool buttons (Select, Movement, Dribble, Pass, Screen, Cut, Eraser), each with a custom SVG basketball-diagram icon
- Keyboard shortcuts: V (select), M (move), D (dribble), P (pass), S (screen), C (cut), E (eraser)
- Active tool is visually highlighted in blue; cursor changes per tool (crosshair for drawing, cell for eraser)
- Adds `AnnotationLayer` — an absolutely-positioned SVG overlay on the court that:
  - Captures pointer events when any drawing tool is active (falls through to player tokens when Select is active)
  - Shows a live preview stroke while drawing
  - Shows a snap-ring around the nearest player when the cursor is within 28 px
  - Snaps start/end points to nearby players and stores `fromPlayer`/`toPlayer` references
  - Renders all 5 annotation types with correct basketball conventions:
    - **Movement** — solid navy arrow line
    - **Dribble** — zigzag wavy arrow
    - **Pass** — straight green arrow with solid triangle tip
    - **Screen** — line with perpendicular bar at end (purple)
    - **Cut** — dashed red arrow line
  - Selected annotation shown with a blue dashed bounding-box ring
  - Delete/Backspace key removes the selected annotation
  - Eraser tool click removes any annotation
  - All annotations committed to the Zustand store's active scene / timing step

## Test plan

- [ ] Open `/play/test` and verify the tools panel appears on the left with 7 buttons
- [ ] Click each tool button — verify active highlight and cursor change
- [ ] Press M, D, P, S, C, E, V on the keyboard — verify tool switches
- [ ] With Movement tool: drag from one player to another — verify solid arrow appears
- [ ] Verify snap ring appears when cursor approaches a player token
- [ ] Click a drawn annotation to select it — verify blue bounding ring
- [ ] Press Delete/Backspace — verify annotation is removed
- [ ] With Eraser active, click an annotation — verify it is removed
- [ ] With Select tool, verify player tokens are still draggable
- [ ] `npm run build && npm run lint && npx tsc --noEmit` — all pass

Closes #56
Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)