### PR TITLE
Fix #53 + #54: player display mode toggle and per-scene visibility

### DIFF
--- a/src/app/play/[id]/page.tsx
+++ b/src/app/play/[id]/page.tsx
@@ -1,5 +1,6 @@
 import EditorCourtArea from "./EditorCourtArea";
 import DrawingToolsPanel from "@/components/editor/DrawingToolsPanel";
+import PlayerRosterPanel from "@/components/editor/PlayerRosterPanel";
 import SceneStrip from "@/components/editor/SceneStrip";
 import PlaybackControls from "@/components/editor/PlaybackControls";
 import TimingStripPanel from "@/components/editor/TimingStripPanel";
@@ -32,11 +33,8 @@ export default function PlayEditorPage({ params }: PlayEditorPageProps) {
         <div className="flex flex-1 items-center justify-center overflow-auto bg-gray-100 p-4">
           <EditorCourtArea />
         </div>
-        {/* Play Info Panel */}
-        <aside className="w-64 border-l border-gray-200 bg-white p-4">
-          <h2 className="mb-2 font-semibold text-gray-700">Play Info</h2>
-          <p className="text-sm text-gray-400">Play details and notes will appear here.</p>
-        </aside>
+        {/* Player roster: display mode + per-scene visibility */}
+        <PlayerRosterPanel />
       </div>
       {/* Timing steps strip */}
       <TimingStripPanel />

--- a/src/components/editor/PlayerRosterPanel.tsx
+++ b/src/components/editor/PlayerRosterPanel.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+/**
+ * PlayerRosterPanel — right-side panel for managing per-scene player visibility
+ * and the global player display mode.
+ *
+ * Implements:
+ *   Issue #53 — Player display mode toggle (numbers / names / abbreviations)
+ *   Issue #54 — Show/hide individual players per scene
+ *
+ * Architecture:
+ *   - Display mode is a global editor setting stored in the Zustand store.
+ *   - Visibility is stored per-player per-scene in the Scene data model.
+ *   - Toggling visibility calls `togglePlayerVisibility` in the store.
+ */
+
+import { useStore, selectEditorScene } from "@/lib/store";
+import type { PlayerDisplayMode } from "@/lib/store";
+
+// ---------------------------------------------------------------------------
+// Display mode toggle button group
+// ---------------------------------------------------------------------------
+
+const DISPLAY_MODES: { id: PlayerDisplayMode; label: string }[] = [
+  { id: "numbers",       label: "#" },
+  { id: "abbreviations", label: "POS" },
+  { id: "names",         label: "NAME" },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function PlayerRosterPanel() {
+  const scene          = useStore(selectEditorScene);
+  const sceneId        = useStore((s) => s.selectedSceneId);
+  const displayMode    = useStore((s) => s.playerDisplayMode);
+  const setDisplayMode = useStore((s) => s.setPlayerDisplayMode);
+  const toggleVisibility = useStore((s) => s.togglePlayerVisibility);
+
+  const offensePlayers = scene?.players.offense ?? [];
+  const defensePlayers = scene?.players.defense ?? [];
+
+  function handleToggle(side: "offense" | "defense", position: number) {
+    if (sceneId) toggleVisibility(sceneId, side, position);
+  }
+
+  return (
+    <aside
+      className="flex w-52 flex-col gap-3 border-l border-gray-200 bg-white p-3 text-sm"
+      aria-label="Player roster and visibility"
+    >
+      {/* ── Display mode ─────────────────────────────────── */}
+      <section>
+        <h2 className="mb-1.5 text-xs font-semibold uppercase tracking-widest text-gray-400">
+          Display
+        </h2>
+        <div className="flex gap-1" role="group" aria-label="Player label mode">
+          {DISPLAY_MODES.map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => setDisplayMode(id)}
+              aria-pressed={displayMode === id}
+              title={id.charAt(0).toUpperCase() + id.slice(1)}
+              className={[
+                "flex-1 rounded-md border px-1 py-1 text-[11px] font-semibold transition-colors",
+                displayMode === id
+                  ? "border-blue-500 bg-blue-500 text-white"
+                  : "border-gray-300 bg-white text-gray-600 hover:border-blue-400 hover:text-blue-600",
+              ].join(" ")}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Offense ─────────────────────────────────────── */}
+      <section>
+        <h2 className="mb-1.5 text-xs font-semibold uppercase tracking-widest text-gray-400">
+          Offense
+        </h2>
+        <ul className="flex flex-col gap-1">
+          {offensePlayers.map((p) => (
+            <li key={p.position} className="flex items-center justify-between">
+              <span className="font-medium text-gray-700">O{p.position}</span>
+              <button
+                onClick={() => handleToggle("offense", p.position)}
+                aria-label={`${p.visible ? "Hide" : "Show"} offensive player ${p.position}`}
+                title={p.visible ? "Click to hide" : "Click to show"}
+                className={[
+                  "rounded px-2 py-0.5 text-[11px] font-medium transition-colors",
+                  p.visible
+                    ? "bg-orange-100 text-orange-700 hover:bg-orange-200"
+                    : "bg-gray-100 text-gray-400 hover:bg-gray-200",
+                ].join(" ")}
+              >
+                {p.visible ? "Visible" : "Hidden"}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* ── Defense ─────────────────────────────────────── */}
+      <section>
+        <h2 className="mb-1.5 text-xs font-semibold uppercase tracking-widest text-gray-400">
+          Defense
+        </h2>
+        <ul className="flex flex-col gap-1">
+          {defensePlayers.map((p) => (
+            <li key={p.position} className="flex items-center justify-between">
+              <span className="font-medium text-gray-700">X{p.position}</span>
+              <button
+                onClick={() => handleToggle("defense", p.position)}
+                aria-label={`${p.visible ? "Hide" : "Show"} defensive player ${p.position}`}
+                title={p.visible ? "Click to hide" : "Click to show"}
+                className={[
+                  "rounded px-2 py-0.5 text-[11px] font-medium transition-colors",
+                  p.visible
+                    ? "bg-blue-100 text-blue-700 hover:bg-blue-200"
+                    : "bg-gray-100 text-gray-400 hover:bg-gray-200",
+                ].join(" ")}
+              >
+                {p.visible ? "Visible" : "Hidden"}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </aside>
+  );
+}

--- a/src/components/players/CourtWithPlayers.tsx
+++ b/src/components/players/CourtWithPlayers.tsx
@@ -131,8 +131,9 @@ export interface CourtWithPlayersProps {
 }
 
 export default function CourtWithPlayers({ sceneId, scene, className }: CourtWithPlayersProps) {
-  const updatePlayerState = useStore((s) => s.updatePlayerState);
-  const updateBallState = useStore((s) => s.updateBallState);
+  const updatePlayerState  = useStore((s) => s.updatePlayerState);
+  const updateBallState    = useStore((s) => s.updateBallState);
+  const displayMode        = useStore((s) => s.playerDisplayMode);
 
   // Court layout reported by the Court canvas
   const [courtSize, setCourtSize] = useState<{ width: number; height: number } | null>(null);
@@ -252,15 +253,16 @@ export default function CourtWithPlayers({ sceneId, scene, className }: CourtWit
 
   const handleOffenseDragEnd = useCallback(
     (position: number, newCx: number, newCy: number) => {
-      setOffensePx((prev) =>
-        prev
-          ? prev.map((p) => (p.position === position ? { ...p, px: newCx, py: newCy } : p))
-          : prev,
-      );
-      if (sceneId && courtSizeRef.current) {
-        const { x, y } = pixelToNorm(newCx, newCy, courtSizeRef.current.width, courtSizeRef.current.height);
-        updatePlayerState(sceneId, "offense", { position, x, y, visible: true });
-      }
+      setOffensePx((prev) => {
+        if (!prev) return prev;
+        const updated = prev.map((p) => (p.position === position ? { ...p, px: newCx, py: newCy } : p));
+        if (sceneId && courtSizeRef.current) {
+          const { x, y } = pixelToNorm(newCx, newCy, courtSizeRef.current.width, courtSizeRef.current.height);
+          const visible = updated.find((p) => p.position === position)?.visible ?? true;
+          updatePlayerState(sceneId, "offense", { position, x, y, visible });
+        }
+        return updated;
+      });
     },
     [sceneId, updatePlayerState],
   );
@@ -275,15 +277,16 @@ export default function CourtWithPlayers({ sceneId, scene, className }: CourtWit
 
   const handleDefenseDragEnd = useCallback(
     (position: number, newCx: number, newCy: number) => {
-      setDefensePx((prev) =>
-        prev
-          ? prev.map((p) => (p.position === position ? { ...p, px: newCx, py: newCy } : p))
-          : prev,
-      );
-      if (sceneId && courtSizeRef.current) {
-        const { x, y } = pixelToNorm(newCx, newCy, courtSizeRef.current.width, courtSizeRef.current.height);
-        updatePlayerState(sceneId, "defense", { position, x, y, visible: true });
-      }
+      setDefensePx((prev) => {
+        if (!prev) return prev;
+        const updated = prev.map((p) => (p.position === position ? { ...p, px: newCx, py: newCy } : p));
+        if (sceneId && courtSizeRef.current) {
+          const { x, y } = pixelToNorm(newCx, newCy, courtSizeRef.current.width, courtSizeRef.current.height);
+          const visible = updated.find((p) => p.position === position)?.visible ?? true;
+          updatePlayerState(sceneId, "defense", { position, x, y, visible });
+        }
+        return updated;
+      });
     },
     [sceneId, updatePlayerState],
   );
@@ -418,6 +421,7 @@ export default function CourtWithPlayers({ sceneId, scene, className }: CourtWit
                   courtBounds={courtSize}
                   onDrag={(x, y) => handleDefenseDrag(p.position, x, y)}
                   onDragEnd={(x, y) => handleDefenseDragEnd(p.position, x, y)}
+                  displayMode={displayMode}
                 />
               ))}
 
@@ -434,6 +438,7 @@ export default function CourtWithPlayers({ sceneId, scene, className }: CourtWit
                   courtBounds={courtSize}
                   onDrag={(x, y) => handleOffenseDrag(p.position, x, y)}
                   onDragEnd={(x, y) => handleOffenseDragEnd(p.position, x, y)}
+                  displayMode={displayMode}
                 />
               ))}
 


### PR DESCRIPTION
## Summary

- **Issue #53 — Player display mode toggle**: adds a `PlayerDisplayMode` type (`"numbers" | "names" | "abbreviations"`) to the Zustand store. A 3-button toggle in the new `PlayerRosterPanel` sidebar lets coaches switch between showing position numbers (O1/X1), position abbreviations (PG/SG/SF/PF/C), or player names (falls back to number when no roster name is supplied). `PlayerToken` reads the mode and scales font size automatically for longer labels.

- **Issue #54 — Show/hide individual players per scene**: a `togglePlayerVisibility` action was added to the store. The `PlayerRosterPanel` lists all 10 players with a per-player Visible/Hidden toggle button. Hidden players are excluded from the SVG overlay and from the snap-to-player list used by the annotation layer. The drag-end handlers in `CourtWithPlayers` were fixed to preserve the existing `visible` flag instead of silently hardcoding `true`.

## Files changed

| File | Change |
|------|--------|
| `src/lib/store.ts` | Add `PlayerDisplayMode` type, `playerDisplayMode` state, `setPlayerDisplayMode`, `togglePlayerVisibility` |
| `src/components/players/PlayerToken.tsx` | Accept `displayMode` + `playerName` props; compute label + adaptive font size |
| `src/components/players/CourtWithPlayers.tsx` | Read `displayMode` from store; pass to `PlayerToken`; preserve `visible` on drag-end |
| `src/components/editor/PlayerRosterPanel.tsx` | New component: display-mode buttons + per-player visibility toggles |
| `src/app/play/[id]/page.tsx` | Replace placeholder aside with `<PlayerRosterPanel />` |

## Test plan

- [ ] Open `/play/test` — right sidebar shows Offense (O1-O5) and Defense (X1-X5) rows, all Visible
- [ ] Click `POS` button — tokens on court switch to PG/SG/SF/PF/C labels
- [ ] Click `NAME` button — tokens fall back to position number (no roster loaded yet)
- [ ] Click `#` button — returns to default O1/X1 numbering
- [ ] Toggle "Visible" → "Hidden" on O3 — token disappears from court immediately
- [ ] Toggle back — token reappears
- [ ] Drag O1 to new position — visibility is preserved (not reset to true)
- [ ] `npm run build` and `npm run lint` both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)