### PR TITLE
Fix #83: Undo/Redo system for all editor actions

### DIFF
--- a/src/app/play/[id]/page.tsx
+++ b/src/app/play/[id]/page.tsx
@@ -6,6 +6,7 @@ import PlaybackControls from "@/components/editor/PlaybackControls";
 import TimingStripPanel from "@/components/editor/TimingStripPanel";
 import EditorKeyboardManager from "@/components/editor/EditorKeyboardManager";
 import ShortcutsButton from "@/components/editor/ShortcutsButton";
+import UndoRedoButtons from "@/components/editor/UndoRedoButtons";
 
 interface PlayEditorPageProps {
   params: { id: string };
@@ -23,7 +24,10 @@ export default function PlayEditorPage({ params }: PlayEditorPageProps) {
 
       <header className="flex items-center justify-between border-b border-gray-200 px-4 py-2">
         <h1 className="text-lg font-semibold text-gray-900">Play Editor — {params.id}</h1>
-        <div className="flex gap-2">
+        <div className="flex items-center gap-2">
+          {/* Undo / Redo buttons (issue #83) */}
+          <UndoRedoButtons />
+          <div className="mx-1 h-5 w-px bg-gray-200" aria-hidden="true" />
           <button
             className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
             title="Save (Ctrl+S)"

--- a/src/components/editor/EditorKeyboardManager.tsx
+++ b/src/components/editor/EditorKeyboardManager.tsx
@@ -5,6 +5,8 @@
  * manages the ShortcutsOverlay visibility for the play editor.
  *
  * Implements issue #82: Keyboard shortcuts.
+ * Implements issue #83: Undo/Redo — wires Ctrl+Z / Ctrl+Shift+Z to the
+ * history store.
  *
  * This is a zero-render client component that:
  *   1. Calls useKeyboardShortcuts with editor-specific callbacks.
@@ -16,10 +18,14 @@
 
 import { useState, useCallback } from "react";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { useStore } from "@/lib/store";
 import ShortcutsOverlay from "./ShortcutsOverlay";
 
 export default function EditorKeyboardManager() {
   const [showHelp, setShowHelp] = useState(false);
+
+  const undo = useStore((s) => s.undo);
+  const redo = useStore((s) => s.redo);
 
   const handleToggleHelp = useCallback(() => {
     setShowHelp((prev) => !prev);
@@ -34,14 +40,14 @@ export default function EditorKeyboardManager() {
     // No-op for now; will be wired to the Firestore persistence layer in #68
   }, []);
 
-  // Undo / Redo — stubbed until undo/redo system (#83) is implemented
+  // Undo / Redo — wired to history store (issue #83)
   const handleUndo = useCallback(() => {
-    // No-op for now; will be wired to the history stack in #83
-  }, []);
+    undo();
+  }, [undo]);
 
   const handleRedo = useCallback(() => {
-    // No-op for now; will be wired to the history stack in #83
-  }, []);
+    redo();
+  }, [redo]);
 
   useKeyboardShortcuts({
     onToggleHelp: handleToggleHelp,

--- a/src/components/editor/ShortcutsOverlay.tsx
+++ b/src/components/editor/ShortcutsOverlay.tsx
@@ -47,8 +47,8 @@ const SECTIONS: ShortcutSection[] = [
   {
     title: "Editing",
     entries: [
-      { keys: ["Ctrl", "Z"], description: "Undo (coming soon)" },
-      { keys: ["Ctrl", "Shift", "Z"], description: "Redo (coming soon)" },
+      { keys: ["Ctrl", "Z"], description: "Undo" },
+      { keys: ["Ctrl", "Shift", "Z"], description: "Redo" },
       { keys: ["Del", "⌫"], description: "Delete selected annotation or scene" },
       { keys: ["Ctrl", "S"], description: "Force save" },
     ],

--- a/src/components/editor/UndoRedoButtons.tsx
+++ b/src/components/editor/UndoRedoButtons.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+/**
+ * UndoRedoButtons — toolbar buttons for undo and redo actions.
+ *
+ * Implements issue #83: Undo/Redo system.
+ *
+ * Reads canUndo / canRedo from the history store and calls the undo/redo
+ * actions on the main store. Buttons are disabled when the stack is empty.
+ *
+ * Keyboard shortcuts (Ctrl+Z / Ctrl+Shift+Z) are handled by
+ * EditorKeyboardManager — this component only provides the UI affordance.
+ */
+
+import { useStore } from "@/lib/store";
+import { useHistoryStore } from "@/lib/history";
+
+function UndoIcon() {
+  return (
+    <svg viewBox="0 0 20 20" width={15} height={15} fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M3 8h9a5 5 0 0 1 0 10H7" />
+      <path d="M3 8l4-4M3 8l4 4" />
+    </svg>
+  );
+}
+
+function RedoIcon() {
+  return (
+    <svg viewBox="0 0 20 20" width={15} height={15} fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M17 8H8a5 5 0 0 0 0 10h5" />
+      <path d="M17 8l-4-4M17 8l-4 4" />
+    </svg>
+  );
+}
+
+export default function UndoRedoButtons() {
+  const undo = useStore((s) => s.undo);
+  const redo = useStore((s) => s.redo);
+  const canUndo = useHistoryStore((s) => s.canUndo);
+  const canRedo = useHistoryStore((s) => s.canRedo);
+
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        onClick={undo}
+        disabled={!canUndo}
+        title="Undo (Ctrl+Z)"
+        aria-label="Undo"
+        className="flex h-8 w-8 items-center justify-center rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-30"
+      >
+        <UndoIcon />
+      </button>
+      <button
+        onClick={redo}
+        disabled={!canRedo}
+        title="Redo (Ctrl+Shift+Z)"
+        aria-label="Redo"
+        className="flex h-8 w-8 items-center justify-center rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-30"
+      >
+        <RedoIcon />
+      </button>
+    </div>
+  );
+}

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,0 +1,134 @@
+/**
+ * history.ts — Undo/Redo history store for the play editor.
+ *
+ * Implements issue #83: Undo/Redo system.
+ *
+ * Architecture:
+ *   We maintain two stacks (past and future) of "snapshots". A snapshot
+ *   captures the entire `currentPlay` plus the `selectedSceneId` — these are
+ *   the only pieces of editor state that benefit from undo/redo (player
+ *   positions, annotations, scenes, timing groups, etc. all live on `currentPlay`).
+ *
+ *   When an undoable action is dispatched the caller invokes `pushSnapshot`
+ *   BEFORE mutating the store. This records the current state. The future
+ *   stack is cleared on every new push (standard undo/redo semantics).
+ *
+ *   `undo` pops the top of `past`, pushes the current snapshot onto `future`,
+ *   and restores the popped snapshot to the main store.
+ *
+ *   `redo` pops the top of `future`, pushes the current snapshot onto `past`,
+ *   and restores the popped snapshot to the main store.
+ *
+ * Stack size is capped at MAX_HISTORY_SIZE to prevent memory growth.
+ *
+ * The history is reset whenever `setCurrentPlay` or `clearCurrentPlay` is
+ * called (i.e. when switching to a different play).
+ */
+
+import { create } from "zustand";
+import type { Play } from "./types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_HISTORY_SIZE = 50;
+
+// ---------------------------------------------------------------------------
+// Snapshot type — what we store per undo step
+// ---------------------------------------------------------------------------
+
+export interface EditorSnapshot {
+  play: Play;
+  selectedSceneId: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// History store interface
+// ---------------------------------------------------------------------------
+
+export interface HistoryStore {
+  past: EditorSnapshot[];
+  future: EditorSnapshot[];
+
+  /** Push a snapshot onto the past stack (clears the future stack). */
+  pushSnapshot: (snapshot: EditorSnapshot) => void;
+
+  /**
+   * Undo: returns the snapshot to restore and updates the stacks.
+   * Returns null if there is nothing to undo.
+   * The caller is expected to apply `currentSnapshot` to the history's future
+   * and restore the returned snapshot to the main store.
+   */
+  undo: (currentSnapshot: EditorSnapshot) => EditorSnapshot | null;
+
+  /**
+   * Redo: returns the snapshot to restore and updates the stacks.
+   * Returns null if there is nothing to redo.
+   */
+  redo: (currentSnapshot: EditorSnapshot) => EditorSnapshot | null;
+
+  /** Reset the history (called on play switch). */
+  resetHistory: () => void;
+
+  /** Whether undo is possible */
+  canUndo: boolean;
+  /** Whether redo is possible */
+  canRedo: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useHistoryStore = create<HistoryStore>()((set, get) => ({
+  past: [],
+  future: [],
+  canUndo: false,
+  canRedo: false,
+
+  pushSnapshot: (snapshot) =>
+    set((state) => {
+      const past = [...state.past, snapshot].slice(-MAX_HISTORY_SIZE);
+      return { past, future: [], canUndo: true, canRedo: false };
+    }),
+
+  undo: (currentSnapshot) => {
+    const { past, future } = get();
+    if (past.length === 0) return null;
+
+    const previous = past[past.length - 1];
+    const newPast = past.slice(0, -1);
+    const newFuture = [currentSnapshot, ...future].slice(0, MAX_HISTORY_SIZE);
+
+    set({
+      past: newPast,
+      future: newFuture,
+      canUndo: newPast.length > 0,
+      canRedo: true,
+    });
+
+    return previous;
+  },
+
+  redo: (currentSnapshot) => {
+    const { past, future } = get();
+    if (future.length === 0) return null;
+
+    const next = future[0];
+    const newFuture = future.slice(1);
+    const newPast = [...past, currentSnapshot].slice(-MAX_HISTORY_SIZE);
+
+    set({
+      past: newPast,
+      future: newFuture,
+      canUndo: true,
+      canRedo: newFuture.length > 0,
+    });
+
+    return next;
+  },
+
+  resetHistory: () =>
+    set({ past: [], future: [], canUndo: false, canRedo: false }),
+}));


### PR DESCRIPTION
## Summary

- Implements a snapshot-based undo/redo history system (issue #83) with a 50-entry stack limit
- Every editor mutation (player moves, annotation CRUD, scene add/remove/duplicate/reorder, timing group changes, ball state, player visibility) is tracked
- History resets automatically when switching to a different play (`setCurrentPlay` / `clearCurrentPlay`)

## Changes

### New files
- **`src/lib/history.ts`** — standalone Zustand store (`useHistoryStore`) with `past`/`future` stacks of `EditorSnapshot` objects (`Play` deep-clone + `selectedSceneId`). Exposes `pushSnapshot`, `undo`, `redo`, `resetHistory`, `canUndo`, `canRedo`.
- **`src/components/editor/UndoRedoButtons.tsx`** — client component rendering disabled-aware Undo/Redo icon buttons in the editor toolbar.

### Modified files
- **`src/lib/store.ts`** — imports `useHistoryStore`; all 13 undoable mutations now call `pushSnapshot` (via `get()`) before applying changes. Added `undo()` and `redo()` store actions that restore snapshots. `setCurrentPlay` / `clearCurrentPlay` call `resetHistory`.
- **`src/components/editor/EditorKeyboardManager.tsx`** — wires `Ctrl+Z` / `Ctrl+Shift+Z` to `store.undo` / `store.redo` (previously stubs).
- **`src/app/play/[id]/page.tsx`** — adds `<UndoRedoButtons />` with a divider in the editor header.
- **`src/components/editor/ShortcutsOverlay.tsx`** — removes "(coming soon)" label from undo/redo shortcut entries.

## Acceptance criteria checklist

- [x] Action history stack with undo/redo
- [x] Supports: player position changes, annotation CRUD, scene add/remove/reorder, timing group changes
- [x] Ctrl+Z / Ctrl+Shift+Z keyboard shortcuts
- [x] Undo/Redo buttons in toolbar
- [x] History resets when switching to a different play
- [x] Stack size limit (50 actions)

## Test plan

- [ ] Draw an annotation, press Ctrl+Z — annotation disappears; Ctrl+Shift+Z — it reappears
- [ ] Drag a player, Ctrl+Z — player returns to prior position
- [ ] Add/remove/duplicate a scene, Ctrl+Z undoes each action
- [ ] Add/remove a timing step, Ctrl+Z undoes
- [ ] Toolbar Undo/Redo buttons are disabled (greyed out) at stack boundaries
- [ ] After 50+ actions, oldest entries are dropped (no memory leak)
- [ ] `npm run build` + `npm run lint` + `npx tsc --noEmit` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)