### PR TITLE
Fix #67 #69: Create new play and playbook grid view

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,9 @@
+import { redirect } from "next/navigation";
+
+/**
+ * Landing page — immediately redirects to the playbook grid view.
+ * The playbook page (issue #69) is the real home screen.
+ */
 export default function Home() {
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
-      <div className="text-center">
-        <h1 className="mb-4 text-4xl font-bold tracking-tight text-gray-900">
-          Basketball Playbook
-        </h1>
-        <p className="mb-8 text-lg text-gray-600">
-          Diagram plays, animate transitions, and share with your team.
-        </p>
-        <div className="flex gap-4 justify-center">
-          <a
-            href="/playbook"
-            className="rounded-md bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-          >
-            Open Playbook
-          </a>
-        </div>
-      </div>
-    </main>
-  );
+  redirect("/playbook");
 }

--- a/src/app/play/[id]/EditorCourtArea.tsx
+++ b/src/app/play/[id]/EditorCourtArea.tsx
@@ -3,29 +3,50 @@
 /**
  * EditorCourtArea — client component that renders the court with draggable players.
  *
- * Bootstraps a default play in the Zustand store (if none is loaded) and
- * wires CourtWithPlayers to the selected scene.
+ * Updated for issue #67/#69: accepts a playId prop. If the store already has
+ * the matching play set as currentPlay we use it directly. Otherwise we look
+ * it up in the plays list (e.g. the user navigated directly via URL) and load
+ * it. As a final fallback we bootstrap a brand-new default play (preserves
+ * existing direct-URL behaviour for development).
  */
 
 import { useEffect } from "react";
 import { useStore, createDefaultPlay, selectEditorScene } from "@/lib/store";
 import CourtWithPlayers from "@/components/players/CourtWithPlayers";
 
-export default function EditorCourtArea() {
+interface EditorCourtAreaProps {
+  playId?: string;
+}
+
+export default function EditorCourtArea({ playId }: EditorCourtAreaProps) {
   const currentPlay = useStore((s) => s.currentPlay);
   const setCurrentPlay = useStore((s) => s.setCurrentPlay);
+  const getPlayById = useStore((s) => s.getPlayById);
+  const addPlay = useStore((s) => s.addPlay);
   const selectedSceneId = useStore((s) => s.selectedSceneId);
   const setSelectedSceneId = useStore((s) => s.setSelectedSceneId);
   const scene = useStore(selectEditorScene);
 
-  // Bootstrap a default play if the editor has no play loaded yet.
   useEffect(() => {
-    if (!currentPlay) {
-      const play = createDefaultPlay();
-      setCurrentPlay(play);
-      setSelectedSceneId(play.scenes[0].id);
+    // If the current play already matches the URL id, nothing to do.
+    if (currentPlay && (!playId || currentPlay.id === playId)) return;
+
+    // Try to find the play in the plays list (user navigated via URL).
+    if (playId) {
+      const found = getPlayById(playId);
+      if (found) {
+        setCurrentPlay(found);
+        setSelectedSceneId(found.scenes[0].id);
+        return;
+      }
     }
-  }, [currentPlay, setCurrentPlay, setSelectedSceneId]);
+
+    // Fallback: bootstrap a new default play (dev convenience).
+    const play = createDefaultPlay();
+    addPlay(play);
+    setCurrentPlay(play);
+    setSelectedSceneId(play.scenes[0].id);
+  }, [playId, currentPlay, setCurrentPlay, getPlayById, addPlay, setSelectedSceneId]);
 
   return (
     /*

--- a/src/app/play/[id]/EditorHeader.tsx
+++ b/src/app/play/[id]/EditorHeader.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+/**
+ * EditorHeader — client component for the play editor page header.
+ *
+ * Shows:
+ *   - Back arrow to /playbook (syncs currentPlay changes back to the list)
+ *   - Current play title (from the Zustand store) or the raw play ID
+ *   - Slot for action buttons (passed as children by the server page)
+ */
+
+import { useCallback } from "react";
+import Link from "next/link";
+import { useStore } from "@/lib/store";
+
+interface EditorHeaderProps {
+  playId: string;
+  children?: React.ReactNode;
+}
+
+export default function EditorHeader({ playId, children }: EditorHeaderProps) {
+  const currentPlay = useStore((s) => s.currentPlay);
+  const updatePlayInList = useStore((s) => s.updatePlayInList);
+
+  const title = currentPlay?.title ?? null;
+
+  // When navigating away, sync any in-flight changes back to the plays list.
+  const handleBack = useCallback(() => {
+    if (currentPlay) {
+      updatePlayInList(currentPlay);
+    }
+  }, [currentPlay, updatePlayInList]);
+
+  return (
+    <header className="flex min-w-0 items-center justify-between border-b border-gray-200 px-3 py-2 md:px-4">
+      <div className="flex min-w-0 items-center gap-2">
+        {/* Back to playbook */}
+        <Link
+          href="/playbook"
+          onClick={handleBack}
+          aria-label="Back to playbook"
+          className="flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-900 transition-colors"
+          title="Back to Playbook"
+        >
+          <svg
+            width={16}
+            height={16}
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M10 3L5 8L10 13"
+              stroke="currentColor"
+              strokeWidth={1.75}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </Link>
+
+        <div className="mx-1 h-4 w-px bg-gray-200 flex-shrink-0" aria-hidden="true" />
+
+        <h1 className="truncate text-base font-semibold text-gray-900 md:text-lg">
+          {title ? (
+            <>
+              <span className="hidden sm:inline text-gray-400 font-normal">Playbook / </span>
+              {title}
+            </>
+          ) : (
+            <>
+              <span className="hidden sm:inline">Play Editor — </span>
+              <span className="font-mono text-gray-500">{playId}</span>
+            </>
+          )}
+        </h1>
+      </div>
+
+      {children}
+    </header>
+  );
+}

--- a/src/app/play/[id]/page.tsx
+++ b/src/app/play/[id]/page.tsx
@@ -9,6 +9,7 @@ import ShortcutsButton from "@/components/editor/ShortcutsButton";
 import UndoRedoButtons from "@/components/editor/UndoRedoButtons";
 import ExportMenu from "@/components/editor/ExportMenu";
 import MobileViewerBanner from "@/components/editor/MobileViewerBanner";
+import EditorHeader from "./EditorHeader";
 
 interface PlayEditorPageProps {
   params: { id: string };
@@ -31,14 +32,8 @@ export default function PlayEditorPage({ params }: PlayEditorPageProps) {
        */}
       <MobileViewerBanner />
 
-      {/* ── Header ─────────────────────────────────────────────────────── */}
-      <header className="flex min-w-0 items-center justify-between border-b border-gray-200 px-3 py-2 md:px-4">
-        <h1 className="truncate text-base font-semibold text-gray-900 md:text-lg">
-          {/* Shorter label on mobile to avoid overflow */}
-          <span className="hidden sm:inline">Play Editor — </span>
-          <span className="font-mono text-gray-500">{params.id}</span>
-        </h1>
-
+      {/* ── Header — client component so it can show play title from store ── */}
+      <EditorHeader playId={params.id}>
         {/* Action buttons — hidden on mobile (viewer-only) */}
         <div className="hidden items-center gap-2 md:flex">
           {/* Undo / Redo buttons (issue #83) */}
@@ -56,7 +51,7 @@ export default function PlayEditorPage({ params }: PlayEditorPageProps) {
           </button>
           <ShortcutsButton />
         </div>
-      </header>
+      </EditorHeader>
 
       {/* ── Main editor area ────────────────────────────────────────────── */}
       <div className="flex min-h-0 flex-1 overflow-hidden">
@@ -71,7 +66,7 @@ export default function PlayEditorPage({ params }: PlayEditorPageProps) {
 
         {/* Court canvas — fills the remaining space */}
         <div className="flex flex-1 items-center justify-center overflow-auto bg-gray-100 p-2 md:p-4">
-          <EditorCourtArea />
+          <EditorCourtArea playId={params.id} />
         </div>
 
         {/*

--- a/src/app/playbook/page.tsx
+++ b/src/app/playbook/page.tsx
@@ -1,15 +1,246 @@
+"use client";
+
+/**
+ * PlaybookPage — the home/dashboard screen for the playbook.
+ *
+ * Implements issues #67 and #69:
+ *   #67 — "New Play" button opens NewPlayModal to create a play with
+ *          title, description, court type, and category.
+ *   #69 — Grid view showing all plays as PlayCard thumbnails.
+ *
+ * State is stored in the Zustand store (Firebase comes later in #45/#68).
+ */
+
+import { useState } from "react";
+import { useStore } from "@/lib/store";
+import NewPlayModal from "@/components/playbook/NewPlayModal";
+import PlayCard from "@/components/playbook/PlayCard";
+
 export default function PlaybookPage() {
+  const plays = useStore((s) => s.plays);
+  const [showModal, setShowModal] = useState(false);
+
   return (
-    <main className="min-h-screen p-8">
-      <div className="mx-auto max-w-7xl">
-        <div className="flex items-center justify-between mb-8">
-          <h1 className="text-3xl font-bold text-gray-900">Team Playbook</h1>
-          <button className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500">
-            + New Play
+    <main
+      style={{
+        minHeight: "100vh",
+        background: "#F9FAFB",
+      }}
+    >
+      {/* Header */}
+      <header
+        style={{
+          borderBottom: "1px solid #E5E7EB",
+          background: "#fff",
+          padding: "0 24px",
+        }}
+      >
+        <div
+          style={{
+            maxWidth: 1280,
+            margin: "0 auto",
+            height: 60,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 16,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            {/* Basketball icon */}
+            <svg
+              width={24}
+              height={24}
+              viewBox="0 0 24 24"
+              fill="none"
+              aria-hidden="true"
+            >
+              <circle cx={12} cy={12} r={10} fill="#F97316" />
+              <path
+                d="M12 2 A10 10 0 0 1 22 12"
+                stroke="#fff"
+                strokeWidth={1.5}
+                fill="none"
+              />
+              <path
+                d="M2 12 A10 10 0 0 1 12 2"
+                stroke="#fff"
+                strokeWidth={1.5}
+                fill="none"
+              />
+              <line x1={12} y1={2} x2={12} y2={22} stroke="#fff" strokeWidth={1.5} />
+              <line x1={2} y1={12} x2={22} y2={12} stroke="#fff" strokeWidth={1.5} />
+              <path
+                d="M4.9 5.6 Q12 10 19.1 5.6"
+                stroke="#fff"
+                strokeWidth={1.2}
+                fill="none"
+              />
+              <path
+                d="M4.9 18.4 Q12 14 19.1 18.4"
+                stroke="#fff"
+                strokeWidth={1.2}
+                fill="none"
+              />
+            </svg>
+            <h1
+              style={{
+                margin: 0,
+                fontSize: 18,
+                fontWeight: 700,
+                color: "#111827",
+                letterSpacing: "-0.01em",
+              }}
+            >
+              Playbook
+            </h1>
+          </div>
+
+          <button
+            onClick={() => setShowModal(true)}
+            aria-label="Create new play"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "8px 18px",
+              borderRadius: 8,
+              border: "none",
+              background: "#4F46E5",
+              color: "#fff",
+              fontSize: 14,
+              fontWeight: 600,
+              cursor: "pointer",
+              transition: "background 0.15s",
+            }}
+            onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "#4338CA"; }}
+            onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "#4F46E5"; }}
+          >
+            <span style={{ fontSize: 18, lineHeight: 1, marginTop: -1 }}>+</span>
+            New Play
           </button>
         </div>
-        <p className="text-gray-500">Your plays will appear here.</p>
+      </header>
+
+      {/* Content */}
+      <div
+        style={{
+          maxWidth: 1280,
+          margin: "0 auto",
+          padding: "32px 24px",
+        }}
+      >
+        {plays.length === 0 ? (
+          /* Empty state */
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              minHeight: 360,
+              gap: 16,
+              textAlign: "center",
+            }}
+          >
+            {/* Court illustration */}
+            <svg
+              width={100}
+              height={94}
+              viewBox="0 0 100 94"
+              aria-hidden="true"
+              style={{ opacity: 0.25 }}
+            >
+              <rect width={100} height={94} fill="#F0C878" rx={8} />
+              <rect x={32} y={56} width={36} height={38} fill="#E07B39" />
+              <rect width={100} height={94} fill="none" stroke="#9CA3AF" strokeWidth={2} rx={8} />
+              <line x1={32} y1={56} x2={68} y2={56} stroke="#9CA3AF" strokeWidth={1.5} />
+              <path
+                d="M 6,66 L 6,56 A 47.6,44.7 0 0 1 94,56 L 94,66"
+                fill="none"
+                stroke="#9CA3AF"
+                strokeWidth={1.5}
+              />
+              <circle cx={50} cy={83} r={4} fill="none" stroke="#9CA3AF" strokeWidth={1.5} />
+            </svg>
+
+            <div>
+              <p
+                style={{
+                  margin: "0 0 6px",
+                  fontSize: 18,
+                  fontWeight: 600,
+                  color: "#374151",
+                }}
+              >
+                No plays yet
+              </p>
+              <p
+                style={{
+                  margin: "0 0 20px",
+                  fontSize: 14,
+                  color: "#9CA3AF",
+                }}
+              >
+                Create your first play to get started.
+              </p>
+              <button
+                onClick={() => setShowModal(true)}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 6,
+                  padding: "10px 22px",
+                  borderRadius: 8,
+                  border: "none",
+                  background: "#4F46E5",
+                  color: "#fff",
+                  fontSize: 14,
+                  fontWeight: 600,
+                  cursor: "pointer",
+                }}
+              >
+                <span style={{ fontSize: 18, lineHeight: 1, marginTop: -1 }}>+</span>
+                Create Play
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            {/* Stats bar */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                marginBottom: 24,
+              }}
+            >
+              <p style={{ margin: 0, fontSize: 14, color: "#6B7280" }}>
+                {plays.length} {plays.length === 1 ? "play" : "plays"}
+              </p>
+            </div>
+
+            {/* Grid */}
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+                gap: 20,
+              }}
+            >
+              {[...plays]
+                .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+                .map((play) => (
+                  <PlayCard key={play.id} play={play} />
+                ))}
+            </div>
+          </>
+        )}
       </div>
+
+      {/* New Play Modal */}
+      {showModal && <NewPlayModal onClose={() => setShowModal(false)} />}
     </main>
   );
 }

--- a/src/components/playbook/NewPlayModal.tsx
+++ b/src/components/playbook/NewPlayModal.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+/**
+ * NewPlayModal — dialog for creating a new play.
+ *
+ * Implements issue #67: Create new play with properties.
+ *
+ * Fields:
+ *   - Title (required)
+ *   - Description (optional)
+ *   - Court type: half / full
+ *   - Category: offense / defense / inbound / press-break / fast-break / oob / special
+ *
+ * On submit: creates a Play via createDefaultPlay, adds it to the plays list,
+ * then navigates to /play/[id] to open the editor.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useStore } from "@/lib/store";
+import { createDefaultPlay } from "@/lib/store";
+import type { Category, CourtType } from "@/lib/types";
+
+interface NewPlayModalProps {
+  onClose: () => void;
+}
+
+const CATEGORY_OPTIONS: { value: Category; label: string }[] = [
+  { value: "offense", label: "Offense" },
+  { value: "defense", label: "Defense" },
+  { value: "inbound", label: "Inbound" },
+  { value: "press-break", label: "Press Break" },
+  { value: "fast-break", label: "Fast Break" },
+  { value: "oob", label: "Out of Bounds" },
+  { value: "special", label: "Special" },
+];
+
+export default function NewPlayModal({ onClose }: NewPlayModalProps) {
+  const router = useRouter();
+  const addPlay = useStore((s) => s.addPlay);
+  const setCurrentPlay = useStore((s) => s.setCurrentPlay);
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [courtType, setCourtType] = useState<CourtType>("half");
+  const [category, setCategory] = useState<Category>("offense");
+  const [error, setError] = useState("");
+
+  const titleRef = useRef<HTMLInputElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Focus title on open
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  function handleOverlayClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === overlayRef.current) onClose();
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = title.trim();
+    if (!trimmed) {
+      setError("Title is required.");
+      titleRef.current?.focus();
+      return;
+    }
+
+    const play = createDefaultPlay();
+    play.title = trimmed;
+    play.description = description.trim();
+    play.courtType = courtType;
+    play.category = category;
+
+    addPlay(play);
+    setCurrentPlay(play);
+    router.push(`/play/${play.id}`);
+    onClose();
+  }
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="new-play-title"
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 100,
+        background: "rgba(0,0,0,0.45)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "16px",
+      }}
+    >
+      <div
+        style={{
+          background: "#fff",
+          borderRadius: 12,
+          boxShadow: "0 8px 40px rgba(0,0,0,0.18)",
+          width: "100%",
+          maxWidth: 460,
+          padding: "28px 28px 24px",
+        }}
+      >
+        <h2
+          id="new-play-title"
+          style={{
+            margin: "0 0 20px",
+            fontSize: 20,
+            fontWeight: 700,
+            color: "#111827",
+          }}
+        >
+          New Play
+        </h2>
+
+        <form onSubmit={handleSubmit} noValidate>
+          {/* Title */}
+          <div style={{ marginBottom: 16 }}>
+            <label
+              htmlFor="play-title"
+              style={{ display: "block", fontSize: 13, fontWeight: 600, color: "#374151", marginBottom: 6 }}
+            >
+              Title <span style={{ color: "#EF4444" }}>*</span>
+            </label>
+            <input
+              id="play-title"
+              ref={titleRef}
+              type="text"
+              value={title}
+              onChange={(e) => {
+                setTitle(e.target.value);
+                if (error) setError("");
+              }}
+              placeholder="e.g. Horns Set, Box Out, 1-3-1 Zone"
+              maxLength={80}
+              style={{
+                width: "100%",
+                boxSizing: "border-box",
+                padding: "8px 12px",
+                border: error ? "1.5px solid #EF4444" : "1.5px solid #D1D5DB",
+                borderRadius: 8,
+                fontSize: 14,
+                color: "#111827",
+                outline: "none",
+              }}
+            />
+            {error && (
+              <p role="alert" style={{ marginTop: 4, fontSize: 12, color: "#EF4444" }}>
+                {error}
+              </p>
+            )}
+          </div>
+
+          {/* Description */}
+          <div style={{ marginBottom: 16 }}>
+            <label
+              htmlFor="play-description"
+              style={{ display: "block", fontSize: 13, fontWeight: 600, color: "#374151", marginBottom: 6 }}
+            >
+              Description <span style={{ color: "#9CA3AF", fontWeight: 400 }}>(optional)</span>
+            </label>
+            <textarea
+              id="play-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Brief notes about this play..."
+              rows={2}
+              maxLength={300}
+              style={{
+                width: "100%",
+                boxSizing: "border-box",
+                padding: "8px 12px",
+                border: "1.5px solid #D1D5DB",
+                borderRadius: 8,
+                fontSize: 14,
+                color: "#111827",
+                resize: "vertical",
+                outline: "none",
+                fontFamily: "inherit",
+              }}
+            />
+          </div>
+
+          {/* Court type + Category row */}
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 24 }}>
+            {/* Court type */}
+            <div>
+              <label
+                htmlFor="play-court-type"
+                style={{ display: "block", fontSize: 13, fontWeight: 600, color: "#374151", marginBottom: 6 }}
+              >
+                Court
+              </label>
+              <select
+                id="play-court-type"
+                value={courtType}
+                onChange={(e) => setCourtType(e.target.value as CourtType)}
+                style={{
+                  width: "100%",
+                  boxSizing: "border-box",
+                  padding: "8px 10px",
+                  border: "1.5px solid #D1D5DB",
+                  borderRadius: 8,
+                  fontSize: 14,
+                  color: "#111827",
+                  background: "#fff",
+                  outline: "none",
+                  cursor: "pointer",
+                }}
+              >
+                <option value="half">Half Court</option>
+                <option value="full">Full Court</option>
+              </select>
+            </div>
+
+            {/* Category */}
+            <div>
+              <label
+                htmlFor="play-category"
+                style={{ display: "block", fontSize: 13, fontWeight: 600, color: "#374151", marginBottom: 6 }}
+              >
+                Category
+              </label>
+              <select
+                id="play-category"
+                value={category}
+                onChange={(e) => setCategory(e.target.value as Category)}
+                style={{
+                  width: "100%",
+                  boxSizing: "border-box",
+                  padding: "8px 10px",
+                  border: "1.5px solid #D1D5DB",
+                  borderRadius: 8,
+                  fontSize: 14,
+                  color: "#111827",
+                  background: "#fff",
+                  outline: "none",
+                  cursor: "pointer",
+                }}
+              >
+                {CATEGORY_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: 10 }}>
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                padding: "8px 18px",
+                borderRadius: 8,
+                border: "1.5px solid #D1D5DB",
+                background: "#fff",
+                fontSize: 14,
+                fontWeight: 500,
+                color: "#374151",
+                cursor: "pointer",
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              style={{
+                padding: "8px 22px",
+                borderRadius: 8,
+                border: "none",
+                background: "#4F46E5",
+                fontSize: 14,
+                fontWeight: 600,
+                color: "#fff",
+                cursor: "pointer",
+              }}
+            >
+              Create Play
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/playbook/PlayCard.tsx
+++ b/src/components/playbook/PlayCard.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+/**
+ * PlayCard — a card in the playbook grid view.
+ *
+ * Implements issue #69: Playbook grid view.
+ *
+ * Shows:
+ *   - Thumbnail of the first scene (reuses the SVG court + dots pattern
+ *     from SceneStrip's SceneThumbnail logic)
+ *   - Play title
+ *   - Scene count
+ *   - Category badge
+ *   - Delete button (with confirmation)
+ *
+ * Clicking the card opens /play/[id] and sets the play as currentPlay.
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useStore } from "@/lib/store";
+import type { Play, Scene } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Inline mini court thumbnail (same logic as SceneStrip's SceneThumbnail)
+// ---------------------------------------------------------------------------
+
+function PlayThumbnail({ scene }: { scene: Scene }) {
+  const W = 200;
+  const H = Math.round(W / (50 / 47)); // ~188 px
+
+  const px = (nx: number) => nx * W;
+  const py = (ny: number) => ny * H;
+
+  return (
+    <svg
+      width={W}
+      height={H}
+      viewBox={`0 0 ${W} ${H}`}
+      aria-hidden="true"
+      style={{ display: "block", width: "100%", height: "auto" }}
+    >
+      {/* Court background */}
+      <rect width={W} height={H} fill="#F0C878" rx={6} />
+
+      {/* Paint */}
+      <rect
+        x={px(0.32)}
+        y={py(0.596)}
+        width={px(0.36)}
+        height={py(0.404)}
+        fill="#E07B39"
+      />
+
+      {/* Court outline */}
+      <rect width={W} height={H} fill="none" stroke="#fff" strokeWidth={1.5} rx={6} />
+
+      {/* Free-throw line */}
+      <line
+        x1={px(0.32)}
+        y1={py(0.596)}
+        x2={px(0.68)}
+        y2={py(0.596)}
+        stroke="#fff"
+        strokeWidth={1}
+      />
+
+      {/* Three-point arc */}
+      <path
+        d={`M ${px(0.06)},${py(0.702)} L ${px(0.06)},${py(0.596)} A ${px(0.476)},${py(0.476)} 0 0 1 ${px(0.94)},${py(0.596)} L ${px(0.94)},${py(0.702)}`}
+        fill="none"
+        stroke="#fff"
+        strokeWidth={1}
+      />
+
+      {/* Basket */}
+      <circle cx={px(0.5)} cy={py(0.888)} r={5} fill="none" stroke="#fff" strokeWidth={1} />
+
+      {/* Offensive players */}
+      {scene.players.offense
+        .filter((p) => p.visible)
+        .map((p) => (
+          <circle
+            key={`o-${p.position}`}
+            cx={px(p.x)}
+            cy={py(p.y)}
+            r={7}
+            fill="#3B82F6"
+            stroke="#fff"
+            strokeWidth={1.5}
+          />
+        ))}
+
+      {/* Defensive players */}
+      {scene.players.defense
+        .filter((p) => p.visible)
+        .map((p) => (
+          <circle
+            key={`d-${p.position}`}
+            cx={px(p.x)}
+            cy={py(p.y)}
+            r={7}
+            fill="#1E3A5F"
+            stroke="#fff"
+            strokeWidth={1.5}
+          />
+        ))}
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Category badge colours
+// ---------------------------------------------------------------------------
+
+const CATEGORY_COLOURS: Record<string, { bg: string; text: string }> = {
+  offense: { bg: "#DBEAFE", text: "#1D4ED8" },
+  defense: { bg: "#FEE2E2", text: "#B91C1C" },
+  inbound: { bg: "#D1FAE5", text: "#065F46" },
+  "press-break": { bg: "#FEF3C7", text: "#92400E" },
+  "fast-break": { bg: "#EDE9FE", text: "#5B21B6" },
+  oob: { bg: "#F3F4F6", text: "#374151" },
+  special: { bg: "#FDF2F8", text: "#9D174D" },
+};
+
+// ---------------------------------------------------------------------------
+// PlayCard
+// ---------------------------------------------------------------------------
+
+interface PlayCardProps {
+  play: Play;
+}
+
+export default function PlayCard({ play }: PlayCardProps) {
+  const router = useRouter();
+  const setCurrentPlay = useStore((s) => s.setCurrentPlay);
+  const removePlay = useStore((s) => s.removePlay);
+  const [hovered, setHovered] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const firstScene = play.scenes[0] ?? null;
+  const sceneCount = play.scenes.length;
+  const categoryColour = CATEGORY_COLOURS[play.category] ?? { bg: "#F3F4F6", text: "#374151" };
+
+  function openPlay() {
+    setCurrentPlay(play);
+    router.push(`/play/${play.id}`);
+  }
+
+  function handleDelete(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    removePlay(play.id);
+  }
+
+  function handleDeleteBlur() {
+    // Reset confirm state if focus leaves
+    setConfirmDelete(false);
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={`Open play: ${play.title}`}
+      onClick={openPlay}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") openPlay(); }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => { setHovered(false); setConfirmDelete(false); }}
+      style={{
+        borderRadius: 12,
+        border: `2px solid ${hovered ? "#6366F1" : "#E5E7EB"}`,
+        background: "#fff",
+        cursor: "pointer",
+        overflow: "hidden",
+        transition: "border-color 0.15s, box-shadow 0.15s",
+        boxShadow: hovered ? "0 4px 20px rgba(99,102,241,0.15)" : "0 1px 4px rgba(0,0,0,0.06)",
+        display: "flex",
+        flexDirection: "column",
+        userSelect: "none",
+      }}
+    >
+      {/* Thumbnail */}
+      <div
+        style={{
+          background: "#F5F3EF",
+          padding: "12px 12px 0",
+          lineHeight: 0,
+        }}
+      >
+        {firstScene ? (
+          <PlayThumbnail scene={firstScene} />
+        ) : (
+          <div
+            style={{
+              width: "100%",
+              paddingBottom: "94%",
+              background: "#E5E7EB",
+              borderRadius: 6,
+            }}
+          />
+        )}
+      </div>
+
+      {/* Info */}
+      <div style={{ padding: "12px 14px 14px", flex: 1, display: "flex", flexDirection: "column", gap: 6 }}>
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 8 }}>
+          <h3
+            style={{
+              margin: 0,
+              fontSize: 15,
+              fontWeight: 700,
+              color: "#111827",
+              lineHeight: 1.3,
+              wordBreak: "break-word",
+            }}
+          >
+            {play.title}
+          </h3>
+
+          {/* Delete button */}
+          <button
+            onClick={handleDelete}
+            onBlur={handleDeleteBlur}
+            aria-label={confirmDelete ? "Confirm delete play" : "Delete play"}
+            title={confirmDelete ? "Click again to confirm delete" : "Delete play"}
+            style={{
+              flexShrink: 0,
+              padding: "3px 8px",
+              borderRadius: 6,
+              border: `1px solid ${confirmDelete ? "#FCA5A5" : "#E5E7EB"}`,
+              background: confirmDelete ? "#FEE2E2" : "transparent",
+              color: confirmDelete ? "#B91C1C" : "#9CA3AF",
+              fontSize: 12,
+              fontWeight: 500,
+              cursor: "pointer",
+              transition: "all 0.15s",
+              opacity: hovered ? 1 : 0,
+              pointerEvents: hovered ? "auto" : "none",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {confirmDelete ? "Sure?" : "Delete"}
+          </button>
+        </div>
+
+        {play.description && (
+          <p
+            style={{
+              margin: 0,
+              fontSize: 12,
+              color: "#6B7280",
+              lineHeight: 1.4,
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical" as const,
+              overflow: "hidden",
+            }}
+          >
+            {play.description}
+          </p>
+        )}
+
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: "auto", paddingTop: 4 }}>
+          {/* Category badge */}
+          <span
+            style={{
+              padding: "2px 8px",
+              borderRadius: 99,
+              background: categoryColour.bg,
+              color: categoryColour.text,
+              fontSize: 11,
+              fontWeight: 600,
+              textTransform: "capitalize",
+              letterSpacing: "0.01em",
+            }}
+          >
+            {play.category.replace("-", " ")}
+          </span>
+
+          {/* Scene count */}
+          <span style={{ fontSize: 12, color: "#9CA3AF", marginLeft: "auto" }}>
+            {sceneCount} {sceneCount === 1 ? "scene" : "scenes"}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Issue #67** — New Play modal with title (required), description, court type, and category fields. On submit, creates the play in the Zustand store and navigates to /play/[id].
- **Issue #69** — Playbook grid: /playbook is now a real dashboard with a responsive card grid showing SVG court thumbnails, play title, scene count, category badge, and hover-to-reveal delete.
- **Store**: added plays array with addPlay, removePlay, updatePlayInList, getPlayById. clearCurrentPlay syncs in-flight editor changes back to the list.
- **Landing page** (/) now redirects to /playbook.
- **EditorCourtArea** loads a play by ID from the store on direct URL navigation.
- **EditorHeader** new client component showing play title and back-arrow to /playbook.

## Test plan

- [ ] Visit / — redirects to /playbook
- [ ] Empty state shows CTA
- [ ] Click New Play — modal opens, title validation works
- [ ] Creating a play navigates to /play/[id] and loads the editor
- [ ] Back arrow returns to /playbook with play card visible
- [ ] Grid cards show thumbnail, title, scene count, category badge
- [ ] Delete with confirm step works
- [ ] npm run build, npm run lint, npx tsc --noEmit all pass

> Note: squash-merge when merging into master.

Generated with [Claude Code](https://claude.com/claude-code)