### PR TITLE
Fix #105: Correct corner three lines and free-throw circle

### DIFF
--- a/src/components/court/Court.tsx
+++ b/src/components/court/Court.tsx
@@ -31,7 +31,6 @@ import {
   CORNER_THREE_RIGHT_X,
   FT_CIRCLE_CENTER_X,
   FT_CIRCLE_CENTER_Y,
-  FT_CIRCLE_RADIUS,
   CENTRE_CIRCLE_RADIUS,
 } from "./courtDimensions";
 
@@ -196,37 +195,29 @@ function drawCourt(canvas: HTMLCanvasElement, cssWidth: number, cssHeight: numbe
   const leftCornerX_ft = CORNER_THREE_LEFT_X * 50; // 3
   const rightCornerX_ft = CORNER_THREE_RIGHT_X * 50; // 47
 
-  // dy from basket to corner three line
-  const dy3 = basketY_ft - cornerY_ft; // positive, basket is below corner line
-  // dx from basket centre to where arc meets the corner line
-  const dx3 = Math.sqrt(23.75 * 23.75 - dy3 * dy3);
-
-  // Angle of the arc endpoints (measured from +x axis, clockwise in canvas)
-  // In canvas y increases downward, so atan2 convention: angle from +x going clockwise.
-  // Left endpoint: basket + (-dx3, -dy3) → angle = atan2(-dy3, -dx3)
-  // Right endpoint: basket + (dx3, -dy3)  → angle = atan2(-dy3,  dx3)
-  const arcAngleLeft = Math.atan2(-dy3, -dx3); // ~between -π and -π/2
-  const arcAngleRight = Math.atan2(-dy3, dx3); // ~between -π/2 and 0
-
   ctx.strokeStyle = COLOR_LINE;
   ctx.lineWidth = COLOR_LINE_WIDTH_PX * FT_PER_PX_X; // scale line width to ft coords
 
-  // Left corner three straight (from left sideline to arc start)
+  // Left corner three straight: vertical line from baseline (y=47) up to 14ft depth
   ctx.beginPath();
-  ctx.moveTo(leftCornerX_ft, cornerY_ft);
-  ctx.lineTo(basketX_ft - dx3, cornerY_ft);
+  ctx.moveTo(leftCornerX_ft, 47);
+  ctx.lineTo(leftCornerX_ft, cornerY_ft);
   ctx.stroke();
 
-  // Right corner three straight (from arc end to right sideline)
+  // Right corner three straight: vertical line from baseline (y=47) up to 14ft depth
   ctx.beginPath();
-  ctx.moveTo(basketX_ft + dx3, cornerY_ft);
+  ctx.moveTo(rightCornerX_ft, 47);
   ctx.lineTo(rightCornerX_ft, cornerY_ft);
   ctx.stroke();
 
-  // Three-point arc (counterclockwise from right endpoint to left endpoint,
+  // Arc angles measured from basket center to each corner x at cornerY_ft
+  const arcAngleLeftCorner = Math.atan2(cornerY_ft - basketY_ft, leftCornerX_ft - basketX_ft);
+  const arcAngleRightCorner = Math.atan2(cornerY_ft - basketY_ft, rightCornerX_ft - basketX_ft);
+
+  // Three-point arc (counterclockwise from right corner to left corner,
   // going through the top of the arc toward the half-court line)
   ctx.beginPath();
-  ctx.arc(basketX_ft, basketY_ft, 23.75, arcAngleRight, arcAngleLeft, true);
+  ctx.arc(basketX_ft, basketY_ft, 23.75, arcAngleRightCorner, arcAngleLeftCorner, true);
   ctx.stroke();
 
   // ------------------------------------------------------------------
@@ -260,19 +251,27 @@ function drawCourt(canvas: HTMLCanvasElement, cssWidth: number, cssHeight: numbe
   // ------------------------------------------------------------------
   // 10. Free-throw circle
   //     Full circle: solid upper half (toward half court), dashed lower half
+  //     Drawn in feet-coordinate system for a true circle.
   // ------------------------------------------------------------------
   ctx.save();
-  ctx.scale(1, scaleY);
+  ctx.scale(1 / FT_PER_PX_X, 1 / FT_PER_PX_Y);
 
-  // Upper semicircle (solid) — into the half court (toward y=0)
+  const ftCenterX_ft = FT_CIRCLE_CENTER_X * 50; // 25ft
+  const ftCenterY_ft = FT_CIRCLE_CENTER_Y * 47;
+  const ftRadius_ft = 6; // 6ft radius
+
+  ctx.strokeStyle = COLOR_LINE;
+  ctx.lineWidth = COLOR_LINE_WIDTH_PX * FT_PER_PX_X;
+
+  // Upper semicircle (solid) — toward half court (counterclockwise π → 0)
   ctx.beginPath();
-  ctx.arc(cx(FT_CIRCLE_CENTER_X), cy(FT_CIRCLE_CENTER_Y) / scaleY, rx(FT_CIRCLE_RADIUS), Math.PI, 0, true);
+  ctx.arc(ftCenterX_ft, ftCenterY_ft, ftRadius_ft, Math.PI, 0, true);
   ctx.stroke();
 
-  // Lower semicircle (dashed) — into the paint (toward y=1)
-  ctx.setLineDash([rx(0.015), rx(0.015)]);
+  // Lower semicircle (dashed) — into the paint (clockwise 0 → π)
+  ctx.setLineDash([0.75, 0.75]);
   ctx.beginPath();
-  ctx.arc(cx(FT_CIRCLE_CENTER_X), cy(FT_CIRCLE_CENTER_Y) / scaleY, rx(FT_CIRCLE_RADIUS), 0, Math.PI, false);
+  ctx.arc(ftCenterX_ft, ftCenterY_ft, ftRadius_ft, 0, Math.PI, false);
   ctx.stroke();
   ctx.setLineDash([]);
 

--- a/src/lib/exportPNG.ts
+++ b/src/lib/exportPNG.ts
@@ -31,7 +31,6 @@ import {
   CORNER_THREE_RIGHT_X,
   FT_CIRCLE_CENTER_X,
   FT_CIRCLE_CENTER_Y,
-  FT_CIRCLE_RADIUS,
   CENTRE_CIRCLE_RADIUS,
 } from "@/components/court/courtDimensions";
 
@@ -106,26 +105,27 @@ function drawCourtOnCanvas(canvas: HTMLCanvasElement): void {
   const leftCornerX_ft = CORNER_THREE_LEFT_X * 50;
   const rightCornerX_ft = CORNER_THREE_RIGHT_X * 50;
 
-  const dy3 = basketY_ft - cornerY_ft;
-  const dx3 = Math.sqrt(23.75 * 23.75 - dy3 * dy3);
-  const arcAngleLeft = Math.atan2(-dy3, -dx3);
-  const arcAngleRight = Math.atan2(-dy3, dx3);
-
   ctx.strokeStyle = COLOR_LINE;
   ctx.lineWidth = COLOR_LINE_WIDTH_PX * FT_PER_PX_X;
 
+  // Left corner three straight: vertical line from baseline (y=47) up to 14ft depth
   ctx.beginPath();
-  ctx.moveTo(leftCornerX_ft, cornerY_ft);
-  ctx.lineTo(basketX_ft - dx3, cornerY_ft);
+  ctx.moveTo(leftCornerX_ft, 47);
+  ctx.lineTo(leftCornerX_ft, cornerY_ft);
   ctx.stroke();
 
+  // Right corner three straight: vertical line from baseline (y=47) up to 14ft depth
   ctx.beginPath();
-  ctx.moveTo(basketX_ft + dx3, cornerY_ft);
+  ctx.moveTo(rightCornerX_ft, 47);
   ctx.lineTo(rightCornerX_ft, cornerY_ft);
   ctx.stroke();
 
+  // Arc angles measured from basket center to each corner x at cornerY_ft
+  const arcAngleLeftCorner = Math.atan2(cornerY_ft - basketY_ft, leftCornerX_ft - basketX_ft);
+  const arcAngleRightCorner = Math.atan2(cornerY_ft - basketY_ft, rightCornerX_ft - basketX_ft);
+
   ctx.beginPath();
-  ctx.arc(basketX_ft, basketY_ft, 23.75, arcAngleRight, arcAngleLeft, true);
+  ctx.arc(basketX_ft, basketY_ft, 23.75, arcAngleRightCorner, arcAngleLeftCorner, true);
   ctx.stroke();
 
   // 7. Restricted area arc
@@ -145,17 +145,26 @@ function drawCourtOnCanvas(canvas: HTMLCanvasElement): void {
   ctx.lineTo(cx(LANE_RIGHT), cy(FT_CIRCLE_CENTER_Y));
   ctx.stroke();
 
-  // 10. Free-throw circle
+  // 10. Free-throw circle — drawn in feet-coordinate system for a true circle
   ctx.save();
-  ctx.scale(1, scaleY);
+  ctx.scale(1 / FT_PER_PX_X, 1 / FT_PER_PX_Y);
 
+  const ftCenterX_ft = FT_CIRCLE_CENTER_X * 50; // 25ft
+  const ftCenterY_ft = FT_CIRCLE_CENTER_Y * 47;
+  const ftRadius_ft = 6; // 6ft radius
+
+  ctx.strokeStyle = COLOR_LINE;
+  ctx.lineWidth = COLOR_LINE_WIDTH_PX * FT_PER_PX_X;
+
+  // Upper semicircle (solid) — toward half court (counterclockwise π → 0)
   ctx.beginPath();
-  ctx.arc(cx(FT_CIRCLE_CENTER_X), cy(FT_CIRCLE_CENTER_Y) / scaleY, rx(FT_CIRCLE_RADIUS), Math.PI, 0, true);
+  ctx.arc(ftCenterX_ft, ftCenterY_ft, ftRadius_ft, Math.PI, 0, true);
   ctx.stroke();
 
-  ctx.setLineDash([rx(0.015), rx(0.015)]);
+  // Lower semicircle (dashed) — into the paint (clockwise 0 → π)
+  ctx.setLineDash([0.75, 0.75]);
   ctx.beginPath();
-  ctx.arc(cx(FT_CIRCLE_CENTER_X), cy(FT_CIRCLE_CENTER_Y) / scaleY, rx(FT_CIRCLE_RADIUS), 0, Math.PI, false);
+  ctx.arc(ftCenterX_ft, ftCenterY_ft, ftRadius_ft, 0, Math.PI, false);
   ctx.stroke();
   ctx.setLineDash([]);
 


### PR DESCRIPTION
## Summary

- **Corner three-point lines**: Redrawn as vertical segments parallel to the sidelines, running from the baseline up to 14ft depth (NBA standard). Previously they were drawn as horizontal lines — incorrect.
- **Arc angles**: Updated to use `atan2(cornerY_ft - basketY_ft, cornerX_ft - basketX_ft)` so the arc starts and ends exactly at the corner x positions.
- **Free-throw circle**: Replaced the distorted `ctx.scale(1, scaleY)` ellipse approach with the same feet-coordinate system (`ctx.scale(1/FT_PER_PX_X, 1/FT_PER_PX_Y)`) used by the three-point arc, giving a geometrically correct 6ft-radius circle.
- **Both files fixed**: `src/components/court/Court.tsx` and `src/lib/exportPNG.ts` (which mirrors the drawing logic for PNG export).
- Removed unused variables (`dy3`, `dx3`, `arcAngleLeft`, `arcAngleRight`) and unused `FT_CIRCLE_RADIUS` import from both files.

## Test plan

- [ ] Build passes: `npm run build`
- [ ] Lint passes: `npm run lint`
- [ ] TypeScript passes: `npx tsc --noEmit`
- [ ] Visually verify corner three lines appear as vertical segments from baseline to 14ft depth on both sides
- [ ] Visually verify three-point arc smoothly connects to the corner lines
- [ ] Visually verify free-throw circle is a true circle (not an oval) at 6ft radius
- [ ] Visually verify free-throw circle upper half is solid, lower half is dashed
- [ ] Verify PNG export via `exportSceneAsPNG` renders correctly with the same fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)