### PR TITLE
Fix: Correct restricted area arc and FT circle orientation

### DIFF
--- a/src/components/court/Court.tsx
+++ b/src/components/court/Court.tsx
@@ -229,7 +229,7 @@ function drawCourt(canvas: HTMLCanvasElement, cssWidth: number, cssHeight: numbe
   // We want the arc on the side toward half-court (y < basketY).
   // That's angles from π (left) to 0 (right), going counterclockwise (through top).
   ctx.beginPath();
-  ctx.arc(basketX_ft, basketY_ft, 4, Math.PI, 0, true);
+  ctx.arc(basketX_ft, basketY_ft, 4, Math.PI, 0, false);
   ctx.stroke();
 
   ctx.restore(); // end ft coordinate system
@@ -263,9 +263,9 @@ function drawCourt(canvas: HTMLCanvasElement, cssWidth: number, cssHeight: numbe
   ctx.strokeStyle = COLOR_LINE;
   ctx.lineWidth = COLOR_LINE_WIDTH_PX * FT_PER_PX_X;
 
-  // Upper semicircle (solid) — toward half court (counterclockwise π → 0)
+  // Upper semicircle (solid) — toward half court (clockwise π → 0, through 12 o'clock)
   ctx.beginPath();
-  ctx.arc(ftCenterX_ft, ftCenterY_ft, ftRadius_ft, Math.PI, 0, true);
+  ctx.arc(ftCenterX_ft, ftCenterY_ft, ftRadius_ft, Math.PI, 0, false);
   ctx.stroke();
 
   // Lower semicircle (dashed) — into the paint (clockwise 0 → π)

--- a/src/lib/exportPNG.ts
+++ b/src/lib/exportPNG.ts
@@ -130,7 +130,7 @@ function drawCourtOnCanvas(canvas: HTMLCanvasElement): void {
 
   // 7. Restricted area arc
   ctx.beginPath();
-  ctx.arc(basketX_ft, basketY_ft, 4, Math.PI, 0, true);
+  ctx.arc(basketX_ft, basketY_ft, 4, Math.PI, 0, false);
   ctx.stroke();
 
   ctx.restore();
@@ -156,9 +156,9 @@ function drawCourtOnCanvas(canvas: HTMLCanvasElement): void {
   ctx.strokeStyle = COLOR_LINE;
   ctx.lineWidth = COLOR_LINE_WIDTH_PX * FT_PER_PX_X;
 
-  // Upper semicircle (solid) — toward half court (counterclockwise π → 0)
+  // Upper semicircle (solid) — toward half court (clockwise π → 0, through 12 o'clock)
   ctx.beginPath();
-  ctx.arc(ftCenterX_ft, ftCenterY_ft, ftRadius_ft, Math.PI, 0, true);
+  ctx.arc(ftCenterX_ft, ftCenterY_ft, ftRadius_ft, Math.PI, 0, false);
   ctx.stroke();
 
   // Lower semicircle (dashed) — into the paint (clockwise 0 → π)


### PR DESCRIPTION
Fixes two arc direction bugs in `Court.tsx` and `exportPNG.ts`.

## Root cause
In the HTML Canvas API with y-down coordinates, `anticlockwise=true` from π→0 draws the **bottom** semicircle (toward the baseline), not the top. Two arcs had this wrong:

- **Restricted area arc**: was facing toward baseline — now faces toward paint/half-court
- **FT circle upper half**: was drawing into the paint (hidden) — now correctly appears above the FT line toward the three-point area

## Changes
- `ctx.arc(..., Math.PI, 0, true)` → `false` for both arcs in `Court.tsx` and `exportPNG.ts`

Please squash-merge.