### PR TITLE
feat: smart scene creation, annotation normalization, FT circle

### DIFF
--- a/src/components/annotations/AnnotationLayer.tsx
+++ b/src/components/annotations/AnnotationLayer.tsx
@@ -77,10 +77,16 @@ interface RenderedAnnotationProps {
   step?: number;
   /** Whether to show the step badge. */
   showStepBadge?: boolean;
+  /** Court canvas pixel dimensions — used to convert stored normalized coords to pixels. */
+  width: number;
+  height: number;
 }
 
-function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge }: RenderedAnnotationProps) {
-  const { from, to, type } = ann;
+function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, width, height }: RenderedAnnotationProps) {
+  const { type } = ann;
+  // Annotations are stored in normalised [0-1] coords. Convert to CSS pixels for rendering.
+  const from = { x: ann.from.x * width, y: ann.from.y * height };
+  const to   = { x: ann.to.x   * width, y: ann.to.y   * height };
   const hitStyle: React.CSSProperties = { cursor: "pointer", pointerEvents: "stroke" };
 
   // Step badge — small circle at the midpoint of the annotation
@@ -505,8 +511,10 @@ export default function AnnotationLayer({
         const annotation: Annotation = {
           id: crypto.randomUUID(),
           type: selectedTool as Annotation["type"],
-          from,
-          to,
+          // Store in normalised [0-1] coords so the store is resolution-independent
+          // and addScene can use annotation endpoints directly as player positions.
+          from: { x: from.x / width, y: from.y / height },
+          to:   { x: to.x   / width, y: to.y   / height },
           fromPlayer: fromNearest
             ? { side: fromNearest.side, position: fromNearest.position }
             : null,
@@ -531,6 +539,8 @@ export default function AnnotationLayer({
       players,
       addAnnotation,
       setSelectedAnnotationId,
+      width,
+      height,
     ],
   );
 
@@ -578,6 +588,8 @@ export default function AnnotationLayer({
           onSelect={handleAnnotationSelect}
           step={annotationStepMap.get(ann.id)}
           showStepBadge={showStepBadges}
+          width={width}
+          height={height}
         />
       ))}
 

--- a/src/components/editor/SceneStrip.tsx
+++ b/src/components/editor/SceneStrip.tsx
@@ -68,9 +68,19 @@ function SceneThumbnail({ scene, compact = false }: { scene: Scene; compact?: bo
         strokeWidth={0.8}
       />
 
-      {/* Three-point arc — rough approximation */}
+      {/* Free-throw circle — top semicircle curving toward half-court */}
       <path
-        d={`M ${px(0.06)},${py(0.702)} L ${px(0.06)},${py(0.596)} A ${px(0.476)},${py(0.476)} 0 0 1 ${px(0.94)},${py(0.596)} L ${px(0.94)},${py(0.702)}`}
+        d={`M ${px(0.32)},${py(0.596)} A ${px(0.18)},${px(0.18)} 0 0 0 ${px(0.68)},${py(0.596)}`}
+        fill="none"
+        stroke="#fff"
+        strokeWidth={0.8}
+      />
+
+      {/* Three-point arc — corner straights + arc curving toward half-court */}
+      {/* Corner straights go from baseline (py(1.0)) up to arc start (py(0.702)). */}
+      {/* Arc uses sweep-flag=0 (counterclockwise) so it bows toward y=0 (half-court). */}
+      <path
+        d={`M ${px(0.06)},${py(1.0)} L ${px(0.06)},${py(0.702)} A ${px(0.476)},${py(0.476)} 0 0 0 ${px(0.94)},${py(0.702)} L ${px(0.94)},${py(1.0)}`}
         fill="none"
         stroke="#fff"
         strokeWidth={0.8}


### PR DESCRIPTION
## Summary

- **Smart scene creation**: When clicking `+` to add a new scene, players now start at the endpoint of their movement/cut/dribble arrows from the previous scene. Ball transfers to the receiver after a pass annotation. Player visibility carries over.

- **Annotation coordinate normalization**: Annotations (`from`/`to`) are now stored in normalized [0–1] coordinates instead of CSS pixels. This makes annotation data resolution-independent and is what enables the smart scene projection. When rendering, coords are scaled to CSS pixels via the court's `width`/`height` props.

- **Free-throw circle in scene thumbnails**: Added the FT circle (top semicircle curving toward half-court) to `SceneThumbnail`. Also carries over the corrected 3-point arc direction from PR #110.

## How smart scene creation works

In `store.ts/addScene`:
1. Copy current scene's player positions + visibility into the new scene
2. For each `movement`, `cut`, or `dribble` annotation that has a `fromPlayer` reference: move that player to `annotation.to` (already in normalized coords)
3. If ball was attached to a player who moved, update ball position
4. For each `pass` annotation with a `toPlayer`: transfer the ball to the receiver's new position

## Test plan

- [ ] Draw a movement arrow from O1 → click `+` → O1 should start at the arrow's endpoint in Scene 2
- [ ] Draw a pass arrow from O1 to O2 → click `+` → ball should be at O2's position in Scene 2
- [ ] Players without any annotations carry their positions forward unchanged
- [ ] Player visibility (hidden/shown) carries over between scenes
- [ ] Drawing annotations still renders correctly (coordinates scale properly)
- [ ] Scene thumbnails now show the FT circle and correct 3P arc direction

> **Note**: This PR is based on `master`. The player-names and other bug fixes from PR #110 are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)