### PR TITLE
Fix scene strip and playback bar out-of-sync

### DIFF
--- a/src/components/editor/SceneStrip.tsx
+++ b/src/components/editor/SceneStrip.tsx
@@ -340,6 +340,7 @@ export default function SceneStrip() {
   const currentPlay = useStore((s) => s.currentPlay);
   const selectedSceneId = useStore((s) => s.selectedSceneId);
   const setSelectedSceneId = useStore((s) => s.setSelectedSceneId);
+  const setCurrentSceneIndex = useStore((s) => s.setCurrentSceneIndex);
   const addScene = useStore((s) => s.addScene);
   const scene = useStore(selectEditorScene);
 
@@ -384,7 +385,7 @@ export default function SceneStrip() {
           totalScenes={scenes.length}
           isActive={s.id === activeId}
           compact={isTablet}
-          onClick={() => setSelectedSceneId(s.id)}
+          onClick={() => { setSelectedSceneId(s.id); setCurrentSceneIndex(i); }}
         />
       ))}
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -366,6 +366,7 @@ export const useStore = create<AppStore>()(
             scenes: [...s.currentPlay.scenes, newScene],
           },
           selectedSceneId: newScene.id,
+          currentSceneIndex: order,
         };
       });
     },
@@ -412,9 +413,11 @@ export const useStore = create<AppStore>()(
           copy,
           ...play.scenes.slice(idx + 1),
         ].map((sc, i) => ({ ...sc, order: i }));
+        const copyIndex = scenes.findIndex((sc) => sc.id === copy.id);
         return {
           currentPlay: { ...play, updatedAt: new Date(), scenes },
           selectedSceneId: copy.id,
+          currentSceneIndex: copyIndex !== -1 ? copyIndex : s.currentSceneIndex,
         };
       });
     },
@@ -668,28 +671,45 @@ export const useStore = create<AppStore>()(
         const scenes = state.currentPlay?.scenes ?? [];
         const nextIndex = state.currentSceneIndex + 1;
         if (nextIndex < scenes.length) {
-          return { currentSceneIndex: nextIndex, currentStep: 1, isPlaying: false };
+          return {
+            currentSceneIndex: nextIndex,
+            currentStep: 1,
+            isPlaying: false,
+            selectedSceneId: scenes[nextIndex]?.id ?? state.selectedSceneId,
+          };
         }
         if (state.loop) {
-          return { currentSceneIndex: 0, currentStep: 1 };
+          return {
+            currentSceneIndex: 0,
+            currentStep: 1,
+            selectedSceneId: scenes[0]?.id ?? state.selectedSceneId,
+          };
         }
         return { isPlaying: false };
       }),
 
     stepBack: () =>
       set((state) => {
+        const scenes = state.currentPlay?.scenes ?? [];
         if (state.currentSceneIndex > 0) {
+          const prevIndex = state.currentSceneIndex - 1;
           return {
-            currentSceneIndex: state.currentSceneIndex - 1,
+            currentSceneIndex: prevIndex,
             currentStep: 1,
             isPlaying: false,
+            selectedSceneId: scenes[prevIndex]?.id ?? state.selectedSceneId,
           };
         }
         return { isPlaying: false };
       }),
 
     setCurrentSceneIndex: (index) =>
-      set({ currentSceneIndex: index, currentStep: 1, isPlaying: false }),
+      set((state) => ({
+        currentSceneIndex: index,
+        currentStep: 1,
+        isPlaying: false,
+        selectedSceneId: state.currentPlay?.scenes[index]?.id ?? state.selectedSceneId,
+      })),
 
     setCurrentStep: (step) => set({ currentStep: step }),
     setSpeed: (speed) => set({ speed }),


### PR DESCRIPTION
## Problem

`selectedSceneId` (drives the blue border in the scene strip) and `currentSceneIndex` (drives the "Scene X/Y" playback bar) were completely independent — clicking a scene card only updated one, stepping forward/back only updated the other.

## Changes

### `src/lib/store.ts`
- **`addScene`**: also sets `currentSceneIndex` to the new scene's order so the playback bar jumps to the new scene
- **`duplicateScene`**: also sets `currentSceneIndex` to the copy's position in the scenes array
- **`stepForward` / `stepBack`**: also update `selectedSceneId` so the scene strip blue border tracks playback navigation
- **`setCurrentSceneIndex`**: also updates `selectedSceneId` to the scene at that array position

### `src/components/editor/SceneStrip.tsx`
- Card `onClick`: now calls both `setSelectedSceneId(s.id)` and `setCurrentSceneIndex(i)` so both state values stay in sync when the user clicks a scene

## Test plan
- [ ] Open a play, add 2–3 scenes
- [ ] Click scene cards — confirm playback bar shows correct "Scene X/Y"
- [ ] Use step forward/back buttons — confirm scene strip blue border follows
- [ ] Add a new scene via [+] — confirm bar jumps to "Scene N/N" and strip shows it selected
- [ ] Duplicate a scene (right-click → Duplicate) — confirm both bar and strip agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)