### PR TITLE
Fix scene thumbnail geometry and screen annotation projection

### DIFF
--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -325,7 +325,7 @@ export const useStore = create<AppStore>()(
             if (!ann.fromPlayer) continue;
             const { side, position } = ann.fromPlayer;
             const validSide = side as "offense" | "defense";
-            if (ann.type === "movement" || ann.type === "cut" || ann.type === "dribble") {
+            if (ann.type === "movement" || ann.type === "cut" || ann.type === "dribble" || ann.type === "screen") {
               // ann.to is stored in normalised [0-1] coords — same space as PlayerState.x/y.
               newScene.players[validSide] = newScene.players[validSide].map((p) =>
                 p.position === position ? { ...p, x: ann.to.x, y: ann.to.y } : p,


### PR DESCRIPTION
## Problems

### 1. Scene thumbnail court markings were wrong
The SVG thumbnail in the scene strip had multiple geometry errors compared to the actual `Court.tsx` canvas (sourced from `courtDimensions.ts`):

| Feature | Was | Correct |
|---|---|---|
| Lane width | 0.32–0.68 (36% of court) | 0.34–0.66 (32% of court, 16ft/50ft) |
| FT circle radius | 0.18×W (spans full lane) | 0.12×W (6ft/50ft), endpoints at 0.38/0.62 |
| FT arc direction | sweep=0 → bows INTO paint | sweep=1 → bows toward half-court ✓ |
| 3P arc flags | large-arc=0, sweep=0 → minor arc toward baseline | large-arc=1, sweep=0 → major CCW arc toward half-court ✓ |
| 3P arc y-radius | `py(0.476)` = squished ellipse | `px(0.475)` = true circle in pixel space |
| Centre circle | Missing | Added (radius 0.12×W, bows into court at y=0) |
| Lane outline | Missing | Added (white stroke rect over paint) |
| Backboard | Missing | Added (4ft from baseline, 6ft wide) |
| Restricted area arc | Missing | Added (4ft radius, bows toward half-court) |

**Root cause of arc confusion**: since the court is 50ft wide × 47ft deep and H = W×47/50, a circle of R feet has the same pixel radius in both x and y: `R/50×W`. So `px()` (not `py()`) is the correct helper for all arc radii.

### 2. Screen annotations didn't advance the screener's position
`addScene()` projected player positions for `movement`, `cut`, and `dribble` annotations, but not `screen`. The screener moves to `ann.to` to set the screen, so `screen` should behave identically to the other movement types.

## Changes
- `src/components/editor/SceneStrip.tsx`: rewrote `SceneThumbnail` SVG with accurate NBA court geometry matching `courtDimensions.ts`
- `src/lib/store.ts`: added `"screen"` to the position-projection condition in `addScene`

## Test plan
- [ ] Open a play — scene strip thumbnail shows correct half-court shape (3P arc bows upward, FT circle smaller than lane, centre circle visible at top)
- [ ] Draw a screen annotation on a player, click [+] — confirm screener appears at the screen position in Scene 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)