### PR TITLE
Full court rendering, play-not-found UX, tool label fix

### DIFF
--- a/src/components/court/Court.tsx
+++ b/src/components/court/Court.tsx
@@ -1,18 +1,21 @@
 "use client";
 
 /**
- * Court component — renders an NBA basketball half court on an HTML5 Canvas.
+ * Court component — renders an NBA basketball court on an HTML5 Canvas.
  *
  * Implements issue #49: Render basketball half court on canvas.
+ * Implements issue #50: Full court rendering.
  *
  * Design:
- *   - Light maple-wood court colour (#F5DEB3 / wheat) with darker line colour.
- *   - All NBA standard markings: paint, free-throw line, free-throw circle,
- *     three-point arc (with corner straights), restricted area arc,
+ *   - Light maple-wood court colour (#F5DEB3 / wheat) with white lines.
+ *   - All NBA standard markings: paint, free-throw line + circle (solid upper,
+ *     dashed lower), three-point arc with corner straights, restricted area arc,
  *     backboard, basket/rim, and half-court line with centre-circle arc.
+ *   - variant="full" draws both ends by mirroring the half-court markings
+ *     around the centre line. Players are positioned in the near (bottom) end.
  *   - Responsive: fills container width and maintains correct aspect ratio.
- *   - Exposes a `courtToCanvas(x, y)` utility via the `onReady` callback so
- *     downstream components can map normalised court coordinates to pixels.
+ *   - Exposes courtToCanvas / playAreaHeight / playAreaOffsetY in onReady so
+ *     CourtWithPlayers can map normalised coords to pixels correctly.
  */
 
 import { useEffect, useRef, useCallback } from "react";
@@ -46,13 +49,29 @@ export type CourtToCanvas = (normX: number, normY: number) => { x: number; y: nu
 export interface CourtReadyPayload {
   canvas: HTMLCanvasElement;
   courtToCanvas: CourtToCanvas;
-  /** Canvas width in CSS pixels. */
+  /** Total canvas width in CSS pixels. */
   width: number;
-  /** Canvas height in CSS pixels. */
+  /** Total canvas height in CSS pixels. */
   height: number;
+  /**
+   * Height of the play area in CSS pixels.
+   * For half court this equals height; for full court it is height/2 (one end).
+   */
+  playAreaHeight: number;
+  /**
+   * Y offset from the canvas top to the play area.
+   * For half court this is 0; for full court it is height/2 (players are in
+   * the near/bottom end of the full court canvas).
+   */
+  playAreaOffsetY: number;
 }
 
 export interface CourtProps {
+  /**
+   * "half" (default) — renders one end of the court.
+   * "full" — renders both ends with the near basket at the bottom.
+   */
+  variant?: CourtVariant;
   /**
    * Optional callback fired whenever the court is (re-)drawn.
    * Useful for overlaying players or annotations on top.
@@ -66,41 +85,28 @@ export interface CourtProps {
 // ---------------------------------------------------------------------------
 const COLOR_COURT = "#F0C878"; // warm maple
 const COLOR_PAINT = "#E07B39"; // standard orange paint
-const COLOR_LINE = "#FFFFFF"; // white lines
+const COLOR_LINE = "#FFFFFF";  // white lines
 const COLOR_LINE_WIDTH_PX = 2; // base line width — scaled by canvas resolution
 
 // ---------------------------------------------------------------------------
-// Drawing helpers
+// Inner half-court drawing helper
 // ---------------------------------------------------------------------------
 
-function drawCourt(canvas: HTMLCanvasElement, cssWidth: number, cssHeight: number): void {
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return;
-
-  const W = cssWidth;
-  const H = cssHeight;
-
-  // Helpers to convert normalised [0-1] court coords → canvas pixels
+/**
+ * Draws one half-court into the current canvas context.
+ *
+ * Assumes the CTM has already been set up so that (0,0) is the half-court line
+ * and (W, H) is the baseline corner. Called for both the near and far ends of a
+ * full court (the far end is drawn with an additional ctx.scale(1,-1) so it
+ * appears mirrored / upside-down, which is the correct NBA full-court layout).
+ */
+function drawHalfCourtInner(ctx: CanvasRenderingContext2D, W: number, H: number): void {
   const cx = (nx: number) => nx * W;
   const cy = (ny: number) => ny * H;
-  // Convert a normalised x-radius → pixels (uses W since x is scaled to width)
   const rx = (nr: number) => nr * W;
-
-  // For arcs that need a pixel radius: the arc is based on the court's physical
-  // radius expressed relative to court width, but when rendered we need the
-  // pixel equivalent. Because W corresponds to COURT_WIDTH_FT and H to
-  // COURT_LENGTH_FT, a radius expressed in normalised-x units maps to rx(r)
-  // pixels in x but potentially a different number in y. We draw arcs in
-  // canvas space where 1px is not necessarily square, so we use a uniform
-  // scale based on W (width) and apply ctx.scale / ellipse where needed.
-  // To keep things simple we apply a non-uniform scale so that a single
-  // canvas unit = 1px in x direction, and squash y accordingly.
-
-  // Scale factor: when drawing a "circle" from physical coords, y must be
-  // scaled by H/W to convert from x-normalised radius to y-normalised radius.
+  // scaleY: factor to convert an x-normalised radius to a y-radius so that
+  // arcs drawn with ctx.scale(1, scaleY) produce true circles in pixel space.
   const scaleY = H / W;
-
-  ctx.clearRect(0, 0, W, H);
 
   // ------------------------------------------------------------------
   // 1. Court background
@@ -128,7 +134,7 @@ function drawCourt(canvas: HTMLCanvasElement, cssWidth: number, cssHeight: numbe
   ctx.strokeRect(0, 0, W, H);
 
   // ------------------------------------------------------------------
-  // 4. Half-court line
+  // 4. Half-court line (top edge, y=0)
   // ------------------------------------------------------------------
   ctx.beginPath();
   ctx.moveTo(0, cy(0));
@@ -136,98 +142,57 @@ function drawCourt(canvas: HTMLCanvasElement, cssWidth: number, cssHeight: numbe
   ctx.stroke();
 
   // ------------------------------------------------------------------
-  // 5. Half-court centre-circle arc (only the half visible in this half)
-  //    The full centre circle has radius 6ft. We draw the semicircle that
-  //    extends into the half court (downward from y=0).
+  // 5. Half-court centre-circle arc (semicircle bowing into the court)
+  //    Uses ctx.scale(1, scaleY) so that a unit radius r in x maps to
+  //    r*W pixels horizontally and r*W pixels vertically (true circle).
   // ------------------------------------------------------------------
   ctx.save();
   ctx.scale(1, scaleY);
   ctx.beginPath();
-  // Arc at (0.5*W, 0) with radius rx(CENTRE_CIRCLE_RADIUS)
-  // Draw the semicircle going into the court (0 to π in canvas coords)
   ctx.arc(cx(0.5), 0, rx(CENTRE_CIRCLE_RADIUS), 0, Math.PI);
   ctx.restore();
   ctx.stroke();
 
   // ------------------------------------------------------------------
-  // 6. Three-point arc
-  // The three-point line consists of:
-  //   a) Two corner straight segments (parallel to baseline)
-  //   b) An arc connecting them, centred on the basket
+  // 6. Three-point arc (in a "feet" coordinate system for a true circle)
   // ------------------------------------------------------------------
+  const FT_PER_PX_X = 50 / W;
+  const FT_PER_PX_Y = 47 / H;
 
-  // We need to find the angles where the arc meets the corner-three y line.
-  // In normalised coords: basket is at (BASKET_X, BASKET_Y)
-  // Corner three y is at CORNER_THREE_Y
-  // The arc has radius THREE_POINT_RADIUS (in x-normalised units)
-  // But because we draw with non-uniform scale, we compute intersection angle
-  // in physical (normalised) space, then map to canvas.
-  //
-  // In normalised coords, the arc is an ellipse:
-  //   ((nx - BASKET_X) / THREE_POINT_RADIUS)^2 + ((ny - BASKET_Y) / (THREE_POINT_RADIUS * H/W))^2 = 1
-  // No — let's think in feet instead.
-  //
-  // Physical: basket at (25ft, basketY_ft) from top-left corner.
-  // THREE_POINT_RADIUS_FT = 23.75
-  // Corner straight at y = CORNER_THREE_Y * H (canvas px from top)
-  //
-  // dy_ft = (BASKET_Y - CORNER_THREE_Y) * COURT_LENGTH_FT (feet from basket to corner-line)
-  // dx_ft = sqrt(23.75^2 - dy_ft^2)
-  // Angles in the canvas's potentially non-square coordinate system require
-  // the ellipse approach.
-  //
-  // Simplest accurate approach: draw the arc using ctx.save()/scale so that
-  // the coordinate system becomes square (1 unit = 1 ft), then the arc is a
-  // true circle.
-
-  const FT_PER_PX_X = 50 / W; // feet per canvas pixel in x
-  const FT_PER_PX_Y = 47 / H; // feet per canvas pixel in y
-
-  // Save and transform to a "feet" coordinate system
   ctx.save();
-  // Scale so that 1 canvas unit = 1 foot
   ctx.scale(1 / FT_PER_PX_X, 1 / FT_PER_PX_Y);
 
-  // In ft coords:
-  const basketX_ft = BASKET_X * 50; // 25
+  const basketX_ft = BASKET_X * 50;
   const basketY_ft = BASKET_Y * 47;
   const cornerY_ft = CORNER_THREE_Y * 47;
-  const leftCornerX_ft = CORNER_THREE_LEFT_X * 50; // 3
-  const rightCornerX_ft = CORNER_THREE_RIGHT_X * 50; // 47
+  const leftCornerX_ft = CORNER_THREE_LEFT_X * 50;
+  const rightCornerX_ft = CORNER_THREE_RIGHT_X * 50;
 
   ctx.strokeStyle = COLOR_LINE;
-  ctx.lineWidth = COLOR_LINE_WIDTH_PX * FT_PER_PX_X; // scale line width to ft coords
+  ctx.lineWidth = COLOR_LINE_WIDTH_PX * FT_PER_PX_X;
 
-  // Left corner three straight: vertical line from baseline (y=47) up to 14ft depth
+  // Left corner straight
   ctx.beginPath();
   ctx.moveTo(leftCornerX_ft, 47);
   ctx.lineTo(leftCornerX_ft, cornerY_ft);
   ctx.stroke();
 
-  // Right corner three straight: vertical line from baseline (y=47) up to 14ft depth
+  // Right corner straight
   ctx.beginPath();
   ctx.moveTo(rightCornerX_ft, 47);
   ctx.lineTo(rightCornerX_ft, cornerY_ft);
   ctx.stroke();
 
-  // Arc angles measured from basket center to each corner x at cornerY_ft
-  const arcAngleLeftCorner = Math.atan2(cornerY_ft - basketY_ft, leftCornerX_ft - basketX_ft);
-  const arcAngleRightCorner = Math.atan2(cornerY_ft - basketY_ft, rightCornerX_ft - basketX_ft);
-
-  // Three-point arc (counterclockwise from right corner to left corner,
-  // going through the top of the arc toward the half-court line)
+  // Arc: counterclockwise from right corner to left corner (major arc over basket)
+  const arcAngleLeft = Math.atan2(cornerY_ft - basketY_ft, leftCornerX_ft - basketX_ft);
+  const arcAngleRight = Math.atan2(cornerY_ft - basketY_ft, rightCornerX_ft - basketX_ft);
   ctx.beginPath();
-  ctx.arc(basketX_ft, basketY_ft, 23.75, arcAngleRightCorner, arcAngleLeftCorner, true);
+  ctx.arc(basketX_ft, basketY_ft, 23.75, arcAngleRight, arcAngleLeft, true);
   ctx.stroke();
 
   // ------------------------------------------------------------------
-  // 7. Restricted area arc (4ft radius from basket)
+  // 7. Restricted area arc (4ft radius, semicircle toward half-court)
   // ------------------------------------------------------------------
-  // Draw semicircle from baseline to free-throw side (angles: π to 0 going counterclockwise,
-  // i.e. the portion inside the court, away from baseline)
-  // In canvas y-down: angles where y < basketY_ft are "upward" i.e. into the court.
-  // We want the arc on the side toward half-court (y < basketY).
-  // That's angles from π (left) to 0 (right), going counterclockwise (through top).
   ctx.beginPath();
   ctx.arc(basketX_ft, basketY_ft, 4, Math.PI, 0, false);
   ctx.stroke();
@@ -235,9 +200,8 @@ function drawCourt(canvas: HTMLCanvasElement, cssWidth: number, cssHeight: numbe
   ctx.restore(); // end ft coordinate system
 
   // ------------------------------------------------------------------
-  // 8. Paint lane outline (drawn over paint fill)
+  // 8. Paint lane outline
   // ------------------------------------------------------------------
-  ctx.beginPath();
   ctx.strokeRect(cx(LANE_LEFT), cy(LANE_TOP), cx(LANE_RIGHT) - cx(LANE_LEFT), cy(1) - cy(LANE_TOP));
 
   // ------------------------------------------------------------------
@@ -249,26 +213,24 @@ function drawCourt(canvas: HTMLCanvasElement, cssWidth: number, cssHeight: numbe
   ctx.stroke();
 
   // ------------------------------------------------------------------
-  // 10. Free-throw circle
-  //     Full circle: solid upper half (toward half court), dashed lower half
-  //     Drawn in feet-coordinate system for a true circle.
+  // 10. Free-throw circle (solid upper arc, dashed lower arc)
   // ------------------------------------------------------------------
   ctx.save();
   ctx.scale(1 / FT_PER_PX_X, 1 / FT_PER_PX_Y);
 
-  const ftCenterX_ft = FT_CIRCLE_CENTER_X * 50; // 25ft
+  const ftCenterX_ft = FT_CIRCLE_CENTER_X * 50;
   const ftCenterY_ft = FT_CIRCLE_CENTER_Y * 47;
-  const ftRadius_ft = 6; // 6ft radius
+  const ftRadius_ft = 6;
 
   ctx.strokeStyle = COLOR_LINE;
   ctx.lineWidth = COLOR_LINE_WIDTH_PX * FT_PER_PX_X;
 
-  // Upper semicircle (solid) — toward half court (clockwise π → 0, through 12 o'clock)
+  // Upper semicircle (solid) — toward half court
   ctx.beginPath();
   ctx.arc(ftCenterX_ft, ftCenterY_ft, ftRadius_ft, Math.PI, 0, false);
   ctx.stroke();
 
-  // Lower semicircle (dashed) — into the paint (clockwise 0 → π)
+  // Lower semicircle (dashed) — into the paint
   ctx.setLineDash([0.75, 0.75]);
   ctx.beginPath();
   ctx.arc(ftCenterX_ft, ftCenterY_ft, ftRadius_ft, 0, Math.PI, false);
@@ -286,7 +248,7 @@ function drawCourt(canvas: HTMLCanvasElement, cssWidth: number, cssHeight: numbe
   ctx.stroke();
 
   // ------------------------------------------------------------------
-  // 12. Basket / rim
+  // 12. Basket / rim (true circle via scale)
   // ------------------------------------------------------------------
   ctx.save();
   ctx.scale(1, scaleY);
@@ -298,10 +260,66 @@ function drawCourt(canvas: HTMLCanvasElement, cssWidth: number, cssHeight: numbe
 }
 
 // ---------------------------------------------------------------------------
+// Top-level draw function
+// ---------------------------------------------------------------------------
+
+function drawCourt(
+  canvas: HTMLCanvasElement,
+  cssWidth: number,
+  cssHeight: number,
+  variant: CourtVariant,
+): void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  ctx.clearRect(0, 0, cssWidth, cssHeight);
+
+  if (variant === "full") {
+    const halfH = cssHeight / 2;
+
+    // Near basket end (bottom half) — normal orientation
+    ctx.save();
+    ctx.translate(0, halfH);
+    drawHalfCourtInner(ctx, cssWidth, halfH);
+    ctx.restore();
+
+    // Far basket end (top half) — mirrored vertically around the centre line
+    ctx.save();
+    ctx.translate(0, halfH);
+    ctx.scale(1, -1);
+    drawHalfCourtInner(ctx, cssWidth, halfH);
+    ctx.restore();
+
+    // Draw the centre line and full centre circle explicitly to avoid any
+    // sub-pixel gap between the two halves.
+    ctx.strokeStyle = COLOR_LINE;
+    ctx.lineWidth = COLOR_LINE_WIDTH_PX;
+    ctx.lineCap = "round";
+
+    ctx.beginPath();
+    ctx.moveTo(0, halfH);
+    ctx.lineTo(cssWidth, halfH);
+    ctx.stroke();
+
+    // Full centre circle (both halves already drew their arcs, so this is just
+    // a reinforcement of the complete circle at the centre line).
+    const scaleY = halfH / cssWidth;
+    ctx.save();
+    ctx.scale(1, scaleY);
+    ctx.beginPath();
+    ctx.arc(cssWidth * 0.5, halfH / scaleY, cssWidth * CENTRE_CIRCLE_RADIUS, 0, Math.PI * 2);
+    ctx.restore();
+    ctx.stroke();
+  } else {
+    drawHalfCourtInner(ctx, cssWidth, cssHeight);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
-export default function Court({ onReady, className }: CourtProps) {
+export default function Court({ variant = "half", onReady, className }: CourtProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -312,7 +330,8 @@ export default function Court({ onReady, className }: CourtProps) {
 
     const dpr = window.devicePixelRatio ?? 1;
     const cssWidth = container.clientWidth;
-    const cssHeight = Math.round(cssWidth / COURT_ASPECT_RATIO);
+    const halfH = Math.round(cssWidth / COURT_ASPECT_RATIO);
+    const cssHeight = variant === "full" ? halfH * 2 : halfH;
 
     // Set CSS size
     canvas.style.width = `${cssWidth}px`;
@@ -327,17 +346,28 @@ export default function Court({ onReady, className }: CourtProps) {
       ctx.scale(dpr, dpr);
     }
 
-    drawCourt(canvas, cssWidth, cssHeight);
+    drawCourt(canvas, cssWidth, cssHeight, variant);
 
-    // Notify parent with coordinate conversion helper
+    // Notify parent with coordinate conversion helper and play-area metadata
     if (onReady) {
+      const playAreaHeight = variant === "full" ? halfH : cssHeight;
+      const playAreaOffsetY = variant === "full" ? halfH : 0;
+
       const courtToCanvas: CourtToCanvas = (normX, normY) => ({
         x: normX * cssWidth,
-        y: normY * cssHeight,
+        y: normY * playAreaHeight + playAreaOffsetY,
       });
-      onReady({ canvas, courtToCanvas, width: cssWidth, height: cssHeight });
+
+      onReady({
+        canvas,
+        courtToCanvas,
+        width: cssWidth,
+        height: cssHeight,
+        playAreaHeight,
+        playAreaOffsetY,
+      });
     }
-  }, [onReady]);
+  }, [variant, onReady]);
 
   useEffect(() => {
     draw();
@@ -354,7 +384,7 @@ export default function Court({ onReady, className }: CourtProps) {
       <canvas
         ref={canvasRef}
         style={{ display: "block" }}
-        aria-label="Basketball half court"
+        aria-label={variant === "full" ? "Basketball full court" : "Basketball half court"}
         role="img"
       />
     </div>

--- a/src/components/editor/DrawingToolsPanel.tsx
+++ b/src/components/editor/DrawingToolsPanel.tsx
@@ -261,7 +261,7 @@ export default function DrawingToolsPanel() {
                 ].join(" ")}
               >
                 <Icon active={active} />
-                <span className="mt-0.5 text-[9px] leading-none">{shortcut}</span>
+                <span className="mt-0.5 text-[9px] leading-none">{label}</span>
               </button>
             );
           })}

--- a/src/components/players/BallToken.tsx
+++ b/src/components/players/BallToken.tsx
@@ -80,7 +80,7 @@ export interface BallTokenProps {
   /** All player positions for snap detection */
   players: NearbyPlayer[];
   /** Court bounding box for clamping */
-  courtBounds: { width: number; height: number };
+  courtBounds: { width: number; height: number; minY?: number };
 }
 
 // ---------------------------------------------------------------------------
@@ -131,7 +131,7 @@ export default function BallToken({
   const clamp = useCallback(
     (x: number, y: number): { x: number; y: number } => ({
       x: Math.max(BALL_RADIUS, Math.min(courtBounds.width - BALL_RADIUS, x)),
-      y: Math.max(BALL_RADIUS, Math.min(courtBounds.height - BALL_RADIUS, y)),
+      y: Math.max((courtBounds.minY ?? 0) + BALL_RADIUS, Math.min(courtBounds.height - BALL_RADIUS, y)),
     }),
     [courtBounds],
   );

--- a/src/components/players/PlayerToken.tsx
+++ b/src/components/players/PlayerToken.tsx
@@ -65,7 +65,7 @@ export interface PlayerTokenProps {
   /** Called when drag ends, signals store should be updated */
   onDragEnd: (newCx: number, newCy: number) => void;
   /** Bounding box (in CSS px) to clamp drag inside the court */
-  courtBounds: { width: number; height: number };
+  courtBounds: { width: number; height: number; minY?: number };
   /**
    * What to display inside the token.
    *   "numbers"       — default positional number (O1, X1 …)
@@ -106,7 +106,7 @@ export default function PlayerToken({
   const clamp = useCallback(
     (x: number, y: number): { x: number; y: number } => ({
       x: Math.max(PLAYER_RADIUS, Math.min(courtBounds.width - PLAYER_RADIUS, x)),
-      y: Math.max(PLAYER_RADIUS, Math.min(courtBounds.height - PLAYER_RADIUS, y)),
+      y: Math.max((courtBounds.minY ?? 0) + PLAYER_RADIUS, Math.min(courtBounds.height - PLAYER_RADIUS, y)),
     }),
     [courtBounds],
   );


### PR DESCRIPTION
## Summary

- **#50 — Full court rendering**: `Court` now accepts `variant="full"`, drawing two mirrored half-courts via a `ctx.scale(1,-1)` transform for the far end. `CourtReadyPayload` exposes `playAreaHeight` and `playAreaOffsetY` so `CourtWithPlayers` correctly maps normalised `[0-1]` player positions to the near (bottom) end of the full canvas. `PlayerToken` and `BallToken` gain `minY` on their `courtBounds` to clamp dragging above the centre line.
- **#84 — Play not found UX**: Instead of silently redirecting via `router.replace`, `EditorCourtArea` now shows a friendly "Play not found" message with a back-to-playbook link when a play URL is opened after a page refresh (plays are in-memory only).
- **#103 — Tool button labels**: `DrawingToolsPanel` now shows tool names ("Move", "Dribble" …) rather than keyboard shortcut letters in the button label under each icon. Shortcuts remain in the tooltip.

## Test plan

- [ ] Half court: players and ball drag/snap correctly as before
- [ ] Switch play to `courtType: "full"` — full court renders with both baskets; players are confined to the bottom half; dragging cannot cross the centre line
- [ ] Resize the browser window with full court — player positions re-project correctly
- [ ] Navigate to `/play/<unknown-id>` — "Play not found" message appears with working back link
- [ ] Drawing tools panel shows label names under icons, tooltips show `Name (Shortcut)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)