### PR TITLE
PDF export — one page per scene

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "playbook",
       "version": "0.1.0",
       "dependencies": {
+        "jspdf": "^4.2.0",
         "next": "14.2.35",
         "react": "^18",
         "react-dom": "^18",
@@ -38,6 +39,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -551,12 +561,25 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
@@ -578,6 +601,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.0",
@@ -1492,6 +1522,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -1674,6 +1714,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1772,6 +1832,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+      "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1785,6 +1857,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -1954,6 +2036,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -2697,6 +2789,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -2706,6 +2809,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -3178,6 +3287,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3248,6 +3371,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -3796,6 +3925,23 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.0.tgz",
+      "integrity": "sha512-hR/hnRevAXXlrjeqU5oahOE+Ln9ORJUB5brLHHqH67A+RBQZuFr5GkbI9XQI8OUFSEezKegsi45QRpc4bGj75Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -4382,6 +4528,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4448,6 +4600,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4817,6 +4976,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -4895,6 +5064,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -4966,6 +5142,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -5284,6 +5470,16 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -5612,6 +5808,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -5648,6 +5854,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -6006,6 +6222,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "jspdf": "^4.2.0",
     "next": "14.2.35",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/play/[id]/EditorHeader.tsx
+++ b/src/app/play/[id]/EditorHeader.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useStore } from "@/lib/store";
 import type { Category, CourtType } from "@/lib/types";
+import { exportPlayToPdf } from "@/lib/exportPdf";
 
 const CATEGORY_OPTIONS: { value: Category; label: string }[] = [
   { value: "offense", label: "Offense" },
@@ -47,6 +48,18 @@ export default function EditorHeader({ playId, children }: EditorHeaderProps) {
   // ---------------------------------------------------------------------------
   // Edit metadata modal
   // ---------------------------------------------------------------------------
+
+  const [isExporting, setIsExporting] = useState(false);
+
+  async function handleExportPdf() {
+    if (!currentPlay || isExporting) return;
+    setIsExporting(true);
+    try {
+      await exportPlayToPdf(currentPlay);
+    } finally {
+      setIsExporting(false);
+    }
+  }
 
   const [showEdit, setShowEdit] = useState(false);
   const [editTitle, setEditTitle] = useState("");
@@ -171,7 +184,42 @@ export default function EditorHeader({ playId, children }: EditorHeaderProps) {
           )}
         </div>
 
-        {children}
+        <div className="flex items-center gap-1.5">
+          {/* PDF export */}
+          <button
+            onClick={handleExportPdf}
+            disabled={!currentPlay || isExporting}
+            aria-label="Export play as PDF"
+            title="Export as PDF"
+            className="flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-900 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {isExporting ? (
+              <svg
+                width={13}
+                height={13}
+                viewBox="0 0 24 24"
+                fill="none"
+                aria-hidden="true"
+                className="animate-spin"
+              >
+                <circle cx={12} cy={12} r={10} stroke="currentColor" strokeWidth={3} strokeDasharray="31.4 31.4" strokeLinecap="round" />
+              </svg>
+            ) : (
+              <svg width={13} height={13} viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                <path
+                  d="M3 16.5A1.5 1.5 0 0 0 4.5 18h11A1.5 1.5 0 0 0 17 16.5V7l-4-4H4.5A1.5 1.5 0 0 0 3 4.5v12z"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  strokeLinejoin="round"
+                />
+                <path d="M13 3v3.5A1.5 1.5 0 0 0 14.5 8H17" stroke="currentColor" strokeWidth={1.5} strokeLinejoin="round" />
+                <path d="M7 13l3 3 3-3M10 16V9" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            )}
+            {isExporting ? "Exporting…" : "PDF"}
+          </button>
+          {children}
+        </div>
       </header>
 
       {/* Edit play modal */}

--- a/src/components/court/Court.tsx
+++ b/src/components/court/Court.tsx
@@ -263,7 +263,7 @@ function drawHalfCourtInner(ctx: CanvasRenderingContext2D, W: number, H: number)
 // Top-level draw function
 // ---------------------------------------------------------------------------
 
-function drawCourt(
+export function drawCourt(
   canvas: HTMLCanvasElement,
   cssWidth: number,
   cssHeight: number,

--- a/src/lib/exportPdf.ts
+++ b/src/lib/exportPdf.ts
@@ -1,0 +1,392 @@
+/**
+ * exportPdf — renders a Play to a multi-page PDF (one page per scene).
+ *
+ * Implements issue #80: PDF export — one page per scene.
+ *
+ * Each page contains:
+ *   - A header row: scene number + note (left), play title (right)
+ *   - The court with all players, ball, and annotations drawn on an
+ *     offscreen canvas and embedded as a JPEG image.
+ *
+ * Rendering is done entirely in the browser via the Canvas 2D API so
+ * no server round-trip is required. jsPDF is dynamically imported to
+ * avoid loading it on the server.
+ *
+ * Coordinate conventions:
+ *   - Player positions are normalised [0-1] in play-area space.
+ *     For half court: play area = full canvas (paOffY = 0).
+ *     For full court: play area = bottom half (paOffY = halfH).
+ *   - Annotations are stored in normalised [0-1] coords relative to the
+ *     FULL canvas (width × height), matching how AnnotationLayer stores them.
+ */
+
+import { drawCourt } from "@/components/court/Court";
+import type { CourtVariant } from "@/components/court/Court";
+import type { Annotation, Play, Scene } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Canvas width in pixels for the export. Higher = sharper in PDF. */
+const EXPORT_W = 1200;
+
+/** Half-court aspect ratio (width / height = 50ft / 47ft). */
+const HALF_COURT_ASPECT = 50 / 47;
+
+/** Player token radius as a fraction of court width. */
+const PLAYER_R = EXPORT_W * 0.03;
+
+/** Ball radius as a fraction of court width. */
+const BALL_R = EXPORT_W * 0.016;
+
+/** Line width for annotations, scaled to canvas. */
+const ANN_LINE_W = EXPORT_W * 0.003;
+
+/** Arrowhead size, scaled to canvas. */
+const ANN_ARROW_SIZE = EXPORT_W * 0.022;
+
+/** Dribble zigzag: one zig per this many canvas pixels along the line. */
+const DRIBBLE_SEGMENT = EXPORT_W * 0.028;
+
+/** Dribble perpendicular offset in canvas pixels. */
+const DRIBBLE_PERP = EXPORT_W * 0.009;
+
+// Annotation colours — match AnnotationLayer.tsx
+const ANN_COLOR: Record<string, string> = {
+  movement: "#1E3A5F",
+  dribble:  "#1E3A5F",
+  pass:     "#059669",
+  screen:   "#7C3AED",
+  cut:      "#DC2626",
+};
+
+// ---------------------------------------------------------------------------
+// Canvas drawing helpers
+// ---------------------------------------------------------------------------
+
+function drawPlayer(
+  ctx: CanvasRenderingContext2D,
+  side: "offense" | "defense",
+  position: number,
+  px: number,
+  py: number,
+  r: number,
+): void {
+  ctx.save();
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+
+  if (side === "offense") {
+    // Filled orange circle
+    ctx.beginPath();
+    ctx.arc(px, py, r, 0, Math.PI * 2);
+    ctx.fillStyle = "#E07B39";
+    ctx.fill();
+    ctx.strokeStyle = "#FFFFFF";
+    ctx.lineWidth = r * 0.15;
+    ctx.stroke();
+
+    // Position number
+    ctx.fillStyle = "#FFFFFF";
+    ctx.font = `bold ${Math.round(r * 0.78)}px system-ui, sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(String(position), px, py);
+  } else {
+    // White circle with navy X
+    ctx.beginPath();
+    ctx.arc(px, py, r, 0, Math.PI * 2);
+    ctx.fillStyle = "#FFFFFF";
+    ctx.fill();
+    ctx.strokeStyle = "#1E3A5F";
+    ctx.lineWidth = r * 0.18;
+    ctx.stroke();
+
+    const x = r * 0.42;
+    ctx.beginPath();
+    ctx.moveTo(px - x, py - x);
+    ctx.lineTo(px + x, py + x);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(px + x, py - x);
+    ctx.lineTo(px - x, py + x);
+    ctx.stroke();
+
+    // Label above the X
+    ctx.fillStyle = "#1E3A5F";
+    ctx.font = `bold ${Math.round(r * 0.58)}px system-ui, sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(`X${position}`, px, py - x - r * 0.22);
+  }
+
+  ctx.restore();
+}
+
+function drawBall(
+  ctx: CanvasRenderingContext2D,
+  px: number,
+  py: number,
+  r: number,
+): void {
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(px, py, r, 0, Math.PI * 2);
+  ctx.fillStyle = "#E07B39";
+  ctx.fill();
+  ctx.strokeStyle = "#1E3A5F";
+  ctx.lineWidth = r * 0.18;
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawArrowHead(
+  ctx: CanvasRenderingContext2D,
+  tipX: number,
+  tipY: number,
+  tailX: number,
+  tailY: number,
+  size: number,
+): void {
+  const dx = tipX - tailX;
+  const dy = tipY - tailY;
+  const len = Math.sqrt(dx * dx + dy * dy);
+  if (len < 1) return;
+  const ux = dx / len;
+  const uy = dy / len;
+  const perp = size * 0.45;
+  ctx.beginPath();
+  ctx.moveTo(tipX, tipY);
+  ctx.lineTo(tipX - ux * size - uy * perp, tipY - uy * size + ux * perp);
+  ctx.lineTo(tipX - ux * size + uy * perp, tipY - uy * size - ux * perp);
+  ctx.closePath();
+  ctx.fill();
+}
+
+function drawAnnotation(
+  ctx: CanvasRenderingContext2D,
+  ann: Annotation,
+  canvasW: number,
+  canvasH: number,
+): void {
+  // Annotations stored in normalised [0-1] coords relative to full canvas.
+  const fx = ann.from.x * canvasW;
+  const fy = ann.from.y * canvasH;
+  const tx = ann.to.x * canvasW;
+  const ty = ann.to.y * canvasH;
+
+  const color = ANN_COLOR[ann.type] ?? "#1E3A5F";
+
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.fillStyle = color;
+  ctx.lineWidth = ANN_LINE_W;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+
+  if (ann.type === "movement" || ann.type === "pass") {
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    ctx.moveTo(fx, fy);
+    ctx.lineTo(tx, ty);
+    ctx.stroke();
+    drawArrowHead(ctx, tx, ty, fx, fy, ANN_ARROW_SIZE);
+
+  } else if (ann.type === "dribble") {
+    const dx = tx - fx;
+    const dy = ty - fy;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const zigCount = Math.max(2, Math.round(len / DRIBBLE_SEGMENT));
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    for (let i = 0; i <= zigCount; i++) {
+      const t = i / zigCount;
+      const mx = fx + dx * t;
+      const my = fy + dy * t;
+      const perp = i % 2 === 0 ? DRIBBLE_PERP : -DRIBBLE_PERP;
+      const px2 = len > 0 ? -dy / len * perp : 0;
+      const py2 = len > 0 ? dx / len * perp : 0;
+      if (i === 0) ctx.moveTo(mx + px2, my + py2);
+      else ctx.lineTo(mx + px2, my + py2);
+    }
+    ctx.stroke();
+    drawArrowHead(ctx, tx, ty, fx, fy, ANN_ARROW_SIZE);
+
+  } else if (ann.type === "screen") {
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    ctx.moveTo(fx, fy);
+    ctx.lineTo(tx, ty);
+    ctx.stroke();
+
+    // Perpendicular bar at the end
+    const dx = tx - fx;
+    const dy = ty - fy;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const ux = len > 0 ? dx / len : 1;
+    const uy = len > 0 ? dy / len : 0;
+    const barLen = ANN_ARROW_SIZE * 0.85;
+    ctx.lineWidth = ANN_LINE_W * 1.2;
+    ctx.beginPath();
+    ctx.moveTo(tx + uy * barLen, ty - ux * barLen);
+    ctx.lineTo(tx - uy * barLen, ty + ux * barLen);
+    ctx.stroke();
+
+  } else if (ann.type === "cut") {
+    ctx.setLineDash([ANN_LINE_W * 4, ANN_LINE_W * 3]);
+    ctx.beginPath();
+    ctx.moveTo(fx, fy);
+    ctx.lineTo(tx, ty);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    drawArrowHead(ctx, tx, ty, fx, fy, ANN_ARROW_SIZE);
+  }
+
+  ctx.setLineDash([]);
+  ctx.restore();
+}
+
+// ---------------------------------------------------------------------------
+// Scene → canvas
+// ---------------------------------------------------------------------------
+
+function renderScene(scene: Scene, courtType: "half" | "full"): HTMLCanvasElement {
+  const halfH = Math.round(EXPORT_W / HALF_COURT_ASPECT);
+  const H = courtType === "full" ? halfH * 2 : halfH;
+
+  // Play-area offset: where players live on the canvas
+  const paH = halfH;
+  const paOffY = courtType === "full" ? halfH : 0;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = EXPORT_W;
+  canvas.height = H;
+
+  // Draw court markings
+  drawCourt(canvas, EXPORT_W, H, courtType as CourtVariant);
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return canvas;
+
+  // Defense (underneath offense)
+  for (const p of scene.players.defense) {
+    if (!p.visible) continue;
+    drawPlayer(ctx, "defense", p.position, p.x * EXPORT_W, p.y * paH + paOffY, PLAYER_R);
+  }
+
+  // Offense
+  for (const p of scene.players.offense) {
+    if (!p.visible) continue;
+    drawPlayer(ctx, "offense", p.position, p.x * EXPORT_W, p.y * paH + paOffY, PLAYER_R);
+  }
+
+  // Ball
+  const ball = scene.ball;
+  if (ball) {
+    let bx = ball.x * EXPORT_W;
+    let by = ball.y * paH + paOffY;
+
+    // If attached to a player, float it above them
+    if (ball.attachedTo) {
+      const pool = ball.attachedTo.side === "offense" ? scene.players.offense : scene.players.defense;
+      const attached = pool.find((p) => p.position === ball.attachedTo!.position);
+      if (attached) {
+        bx = attached.x * EXPORT_W;
+        by = attached.y * paH + paOffY - PLAYER_R * 1.2;
+      }
+    }
+    drawBall(ctx, bx, by, BALL_R);
+  }
+
+  // Annotations — stored in full-canvas-normalised coords
+  for (const group of scene.timingGroups) {
+    for (const ann of group.annotations) {
+      drawAnnotation(ctx, ann, EXPORT_W, H);
+    }
+  }
+
+  return canvas;
+}
+
+// ---------------------------------------------------------------------------
+// PDF assembly
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates and downloads a PDF of the given play.
+ * One page per scene, with the court rendered on each page.
+ */
+export async function exportPlayToPdf(play: Play): Promise<void> {
+  // Dynamic import keeps jsPDF out of the SSR bundle
+  const { jsPDF } = await import("jspdf");
+
+  const PAGE_W = 210;   // A4 portrait width (mm)
+  const PAGE_H = 297;   // A4 portrait height (mm)
+  const MARGIN = 12;    // page margin (mm)
+  const HEADER_H = 16;  // height reserved for scene/play title row (mm)
+
+  const usableW = PAGE_W - 2 * MARGIN;
+  const usableH = PAGE_H - 2 * MARGIN - HEADER_H;
+
+  const pdf = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
+
+  const scenes = [...play.scenes].sort((a, b) => a.order - b.order);
+
+  for (let i = 0; i < scenes.length; i++) {
+    const scene = scenes[i];
+
+    if (i > 0) pdf.addPage();
+
+    // Render court + players + ball + annotations
+    const canvas = renderScene(scene, play.courtType);
+    const imgData = canvas.toDataURL("image/jpeg", 0.92);
+
+    // Scale to fit usable area while preserving aspect ratio
+    const imgAspect = canvas.width / canvas.height;
+    let imgW: number;
+    let imgH: number;
+    if (imgAspect >= usableW / usableH) {
+      imgW = usableW;
+      imgH = usableW / imgAspect;
+    } else {
+      imgH = usableH;
+      imgW = usableH * imgAspect;
+    }
+    const imgX = MARGIN + (usableW - imgW) / 2;
+    const imgY = MARGIN + HEADER_H;
+
+    // --- Header row ---
+    const sceneLabel = `Scene ${scene.order}`;
+
+    pdf.setFont("helvetica", "bold");
+    pdf.setFontSize(11);
+    pdf.setTextColor(31, 41, 55);
+    pdf.text(sceneLabel, MARGIN, MARGIN + 8);
+
+    if (scene.note) {
+      const labelW = pdf.getTextWidth(sceneLabel);
+      pdf.setFont("helvetica", "normal");
+      pdf.setFontSize(9);
+      pdf.setTextColor(107, 114, 128);
+      pdf.text(scene.note, MARGIN + labelW + 3, MARGIN + 8);
+    }
+
+    // Play title — right-aligned
+    pdf.setFont("helvetica", "normal");
+    pdf.setFontSize(9);
+    pdf.setTextColor(156, 163, 175);
+    pdf.text(play.title, PAGE_W - MARGIN, MARGIN + 8, { align: "right" });
+
+    // Thin divider under header
+    pdf.setDrawColor(229, 231, 235);
+    pdf.setLineWidth(0.3);
+    pdf.line(MARGIN, MARGIN + HEADER_H - 2, PAGE_W - MARGIN, MARGIN + HEADER_H - 2);
+
+    // --- Court image ---
+    pdf.addImage(imgData, "JPEG", imgX, imgY, imgW, imgH);
+  }
+
+  const safe = play.title.replace(/[^\w\s-]/g, "").trim() || "play";
+  pdf.save(`${safe}.pdf`);
+}


### PR DESCRIPTION
## Summary

- **#80** — Adds a **PDF** button to the editor header. Clicking it renders every scene in the current play into a multi-page A4 PDF and triggers a browser download.

## How it works

- **Client-side only** — no server round-trip. jsPDF is dynamically imported so it stays out of the SSR bundle.
- For each scene (sorted by `order`), an offscreen `<canvas>` is created and drawn into:
  1. **Court** via the now-exported `drawCourt()` from `Court.tsx`
  2. **Defensive players** — white circles with navy X marks
  3. **Offensive players** — filled orange circles with position numbers
  4. **Ball** — orange circle; floated above the attached player if attached
  5. **Annotations** — all five types (`movement`, `dribble`, `pass`, `screen`, `cut`) reproduced with the same colours as the interactive SVG layer
- The canvas is embedded as a JPEG into jsPDF and scaled to fill the usable A4 area at correct aspect ratio (full-court layouts are height-constrained and centred).
- Each page header shows: scene number + note (left) / play title (right), separated by a thin rule.

## Test plan

- [ ] Open a play, click **PDF** — file downloads as `<play-title>.pdf`
- [ ] PDF contains one page per scene in scene order
- [ ] Court markings, players, ball, and annotations all render correctly
- [ ] Full-court plays fit the page without overflow
- [ ] Scene note and play title appear in the header row
- [ ] Button shows a spinner while exporting and re-enables after

🤖 Generated with [Claude Code](https://claude.com/claude-code)