### PR TITLE
Fix playback: continuous scene advance and progressive step reveal

### DIFF
--- a/src/components/annotations/AnnotationLayer.tsx
+++ b/src/components/annotations/AnnotationLayer.tsx
@@ -406,8 +406,17 @@ export default function AnnotationLayer({
   const setSelectedAnnotationId = useStore((s) => s.setSelectedAnnotationId);
   const addAnnotation = useStore((s) => s.addAnnotation);
   const removeAnnotation = useStore((s) => s.removeAnnotation);
+  const isPlaying = useStore((s) => s.isPlaying);
+  const currentStep = useStore((s) => s.currentStep);
   const scene = useStore(selectEditorScene);
-  const annotations = selectAllAnnotations(scene);
+
+  // During playback: progressive reveal — show only annotations from steps 1..currentStep.
+  // While editing: show all annotations (with step badges when there are multiple steps).
+  const annotations = isPlaying
+    ? (scene?.timingGroups ?? [])
+        .filter((g) => g.step <= currentStep)
+        .flatMap((g) => g.annotations)
+    : selectAllAnnotations(scene);
 
   // Build a map from annotation id → timing step for badge display
   const annotationStepMap = new Map<string, number>();

--- a/src/components/editor/PlaybackControls.tsx
+++ b/src/components/editor/PlaybackControls.tsx
@@ -147,19 +147,26 @@ export default function PlaybackControls() {
         if (stepIndex < sortedGroups.length - 1) {
           state.setCurrentStep(sortedGroups[stepIndex + 1].step);
         } else {
-          // End of last step — move to next scene
+          // End of last step — move to next scene.
+          // Use useStore.setState directly (not setCurrentSceneIndex) to avoid
+          // the action's isPlaying:false side-effect which would kill the loop.
           const nextSceneIdx = sceneIdx + 1;
           if (nextSceneIdx < scenes.length) {
-            state.setCurrentSceneIndex(nextSceneIdx);
-            // Set to first step of next scene
             const nextScene = scenes[nextSceneIdx];
             const nextSteps = [...nextScene.timingGroups].sort((a, b) => a.step - b.step);
-            state.setCurrentStep(nextSteps[0]?.step ?? 1);
+            useStore.setState({
+              currentSceneIndex: nextSceneIdx,
+              currentStep: nextSteps[0]?.step ?? 1,
+              selectedSceneId: nextScene.id,
+            });
           } else if (state.loop) {
-            state.setCurrentSceneIndex(0);
             const firstScene = scenes[0];
             const firstSteps = [...firstScene.timingGroups].sort((a, b) => a.step - b.step);
-            state.setCurrentStep(firstSteps[0]?.step ?? 1);
+            useStore.setState({
+              currentSceneIndex: 0,
+              currentStep: firstSteps[0]?.step ?? 1,
+              selectedSceneId: firstScene.id,
+            });
           } else {
             // Playback complete
             state.pausePlayback();


### PR DESCRIPTION
## Summary

- **Bug 1 — Playback stops between scenes**: `setCurrentSceneIndex` had an `isPlaying: false` side-effect baked in (used for manual scene nav). The `requestAnimationFrame` loop called this when crossing scene boundaries, which paused itself. Fixed by using `useStore.setState` directly in the playback loop to update `currentSceneIndex` / `currentStep` / `selectedSceneId` without touching `isPlaying`.

- **Bug 2 — All step annotations show at once**: `AnnotationLayer` rendered every annotation in the scene regardless of the current playback step. During playback, annotations are now filtered to steps `1..currentStep`, so step 1 only shows step-1 arrows, step 2 reveals step-1 + step-2 arrows, and so on.

## Test plan

- [ ] Create a play with 3 scenes, each with 2 timing steps and annotations on each step
- [ ] Click Play from scene 1 — confirm it advances continuously through all 3 scenes and stops at the end
- [ ] Confirm each step only reveals its own annotations (step 1 arrows only; step 2 adds its arrows on top)
- [ ] Toggle Loop — confirm playback wraps from scene 3 back to scene 1 seamlessly
- [ ] Confirm the scene indicator in the playback bar updates while playing
- [ ] Click a scene pill mid-playback — confirm it pauses and jumps (existing behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)