### PR TITLE
Fix mobile: scale player/ball tokens proportionally to court width

### DIFF
--- a/src/app/play/[id]/page.tsx
+++ b/src/app/play/[id]/page.tsx
@@ -67,7 +67,7 @@ export default function PlayEditorPage({ params }: PlayEditorPageProps) {
         </div>
 
         {/* Court canvas — fills the remaining space */}
-        <div className="flex flex-1 items-center justify-center overflow-auto bg-gray-100 p-2 md:p-4">
+        <div className="flex flex-1 items-center justify-center overflow-auto bg-gray-100 p-0 md:p-4">
           <EditorCourtArea playId={params.id} />
         </div>
 

--- a/src/components/players/BallToken.tsx
+++ b/src/components/players/BallToken.tsx
@@ -81,6 +81,8 @@ export interface BallTokenProps {
   players: NearbyPlayer[];
   /** Court bounding box for clamping */
   courtBounds: { width: number; height: number; minY?: number };
+  /** Visual radius in CSS pixels. Defaults to BALL_RADIUS (12). */
+  radius?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -119,6 +121,7 @@ export default function BallToken({
   onDragEnd,
   players,
   courtBounds,
+  radius = BALL_RADIUS,
 }: BallTokenProps) {
   const isDragging = useRef(false);
   const dragStart = useRef<{ mouseX: number; mouseY: number; ballCx: number; ballCy: number }>({
@@ -130,10 +133,10 @@ export default function BallToken({
 
   const clamp = useCallback(
     (x: number, y: number): { x: number; y: number } => ({
-      x: Math.max(BALL_RADIUS, Math.min(courtBounds.width - BALL_RADIUS, x)),
-      y: Math.max((courtBounds.minY ?? 0) + BALL_RADIUS, Math.min(courtBounds.height - BALL_RADIUS, y)),
+      x: Math.max(radius, Math.min(courtBounds.width - radius, x)),
+      y: Math.max((courtBounds.minY ?? 0) + radius, Math.min(courtBounds.height - radius, y)),
     }),
-    [courtBounds],
+    [courtBounds, radius],
   );
 
   // -------------------------------------------------------------------------
@@ -234,7 +237,7 @@ export default function BallToken({
   // Render
   // -------------------------------------------------------------------------
 
-  const r = BALL_RADIUS;
+  const r = radius;
 
   return (
     <g


### PR DESCRIPTION
## Summary

- **Players too big on mobile**: `PLAYER_RADIUS = 18` and `BALL_RADIUS = 12` were hardcoded constants. On a ~390px mobile court they caused tokens to visually overlap each other.
- **CourtWithPlayers** now computes `tokenRadius = max(10, round(courtWidth × 0.03))` and `ballRadius = max(7, round(courtWidth × 0.02))` once the court canvas reports its size. On a 390px mobile court this gives ~12px player radius and ~8px ball radius vs 18/12 before.
- **PlayerToken** accepts a `radius` prop and scales all dependent values proportionally: X-lines, stroke width, font size, and label vertical offset.
- **BallToken** accepts a `radius` prop for visual rendering; snap/detach radii are unchanged.
- Ball attach offset now scales with token sizes so the ball still floats neatly above the attached player.
- Removed `p-2` mobile padding from the court container so the court fills the full viewport width.

## Test plan

- [ ] Open on mobile (390px) — player tokens are smaller and no longer overlap
- [ ] Open on desktop (≥768px) — player tokens are the same size as before (~18px radius)
- [ ] Drag players — clamping still works at all screen sizes
- [ ] Ball snaps to players on drag-end, floats above attached player correctly
- [ ] TypeScript: `npx tsc --noEmit` exits clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)