### PR TITLE
Fix #124: Show personal plays in team playbook and allow adding them to team

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -17,6 +17,7 @@ import {
   getDocs,
   setDoc,
   deleteDoc,
+  updateDoc,
   query,
   where,
   serverTimestamp,
@@ -110,4 +111,12 @@ export async function loadPlaysForUser(userId: string): Promise<Play[]> {
   const q = query(collection(db, "plays"), where("createdBy", "==", userId));
   const snap = await getDocs(q);
   return snap.docs.map((d) => deserialisePlay(d.id, d.data()));
+}
+
+/**
+ * Transfer a personal play to a team by setting its teamId field.
+ * The play owner (admin/editor) must have write access to the document.
+ */
+export async function addPlayToTeam(playId: string, teamId: string): Promise<void> {
+  await updateDoc(doc(db, "plays", playId), { teamId });
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -52,6 +52,8 @@ export interface AppStore {
   duplicatePlay: (playId: string) => void;
   updatePlayInList: (play: Play) => void;
   getPlayById: (playId: string) => Play | undefined;
+  /** Update the teamId of a play in the local store after it is added to a team. */
+  updatePlayTeamId: (playId: string, teamId: string) => void;
 
   // ------- Play data -------
   currentPlay: Play | null;
@@ -255,6 +257,13 @@ export const useStore = create<AppStore>()(
       })),
 
     getPlayById: (playId) => get().plays.find((p) => p.id === playId),
+
+    updatePlayTeamId: (playId, teamId) =>
+      set((state) => ({
+        plays: state.plays.map((p) =>
+          p.id === playId ? { ...p, teamId } : p,
+        ),
+      })),
 
     // =======================================================================
     // Play data


### PR DESCRIPTION
## Summary

Resolves #124.

When a user belongs to a team the playbook previously only showed team plays, making any pre-existing personal plays invisible. This PR fixes that by:

- **Loading both sets of plays in parallel** (`loadPlaysForTeam` + `loadPlaysForUser`) when the user is in a team, then deduplicating by `id` before populating the store.
- **Visually distinguishing personal plays** with a subtle yellow "Personal" badge so users can tell them apart from team plays at a glance.
- **Allowing admins and editors to add a personal play to the team** via a new "+ Team" hover action button on each personal `PlayCard`. The button calls the new `addPlayToTeam` Firestore helper and then updates local Zustand state immediately — no page reload required.

## Files changed

| File | Change |
|---|---|
| `src/lib/db.ts` | Add `addPlayToTeam(playId, teamId)` — `updateDoc` call to set `teamId` |
| `src/lib/store.ts` | Add `updatePlayTeamId(playId, teamId)` store action |
| `src/app/playbook/page.tsx` | Load + merge personal and team plays; pass `teamId`/`role` to `PlayCard` |
| `src/components/playbook/PlayCard.tsx` | "Personal" badge, "+ Team" button with loading/disabled state |

## Test plan

- [ ] Solo user (no team): playbook shows only their own plays — no change in behaviour.
- [ ] Team user (viewer): personal plays appear with "Personal" badge; no "+ Team" button is shown.
- [ ] Team user (editor / admin): personal plays show "Personal" badge **and** a "+ Team" hover button.
  - Click "+ Team": button shows "Adding…", then disappears (play is now a team play and the badge is gone).
  - Reload the page: the play appears in the team plays list (no badge).
- [ ] A play that already has `teamId` set is not shown as personal.
- [ ] `npx tsc --noEmit` passes with zero errors.

> Note: Please **squash-and-merge** this PR to keep the commit history linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)