### PR TITLE
Fix broken 3-point arc in scene/play thumbnails

### DIFF
--- a/src/components/editor/SceneStrip.tsx
+++ b/src/components/editor/SceneStrip.tsx
@@ -78,9 +78,9 @@ function SceneThumbnail({ scene, compact = false }: { scene: Scene; compact?: bo
       />
 
       {/* Three-point line: corner straights + arc */}
-      {/* Arc: major arc (large-arc=1) going counterclockwise (sweep=0) = upward over half-court */}
+      {/* Arc: minor arc (large-arc=0) going clockwise (sweep=1) = bows upward over basket */}
       <path
-        d={`M ${px(0.06)},${py(1)} L ${px(0.06)},${py(0.702)} A ${px(0.475)},${px(0.475)} 0 1 0 ${px(0.94)},${py(0.702)} L ${px(0.94)},${py(1)}`}
+        d={`M ${px(0.06)},${py(1)} L ${px(0.06)},${py(0.702)} A ${px(0.475)},${px(0.475)} 0 0 1 ${px(0.94)},${py(0.702)} L ${px(0.94)},${py(1)}`}
         fill="none"
         stroke="#fff"
         strokeWidth={0.8}

--- a/src/components/playbook/PlayCard.tsx
+++ b/src/components/playbook/PlayCard.tsx
@@ -67,9 +67,9 @@ function PlayThumbnail({ scene }: { scene: Scene }) {
         strokeWidth={1}
       />
 
-      {/* Three-point line: corner straights + major arc (large-arc=1, sweep=0) */}
+      {/* Three-point line: corner straights + minor arc (large-arc=0, sweep=1) bowing upward */}
       <path
-        d={`M ${px(0.06)},${py(1)} L ${px(0.06)},${py(0.702)} A ${px(0.475)},${px(0.475)} 0 1 0 ${px(0.94)},${py(0.702)} L ${px(0.94)},${py(1)}`}
+        d={`M ${px(0.06)},${py(1)} L ${px(0.06)},${py(0.702)} A ${px(0.475)},${px(0.475)} 0 0 1 ${px(0.94)},${py(0.702)} L ${px(0.94)},${py(1)}`}
         fill="none"
         stroke="#fff"
         strokeWidth={1}


### PR DESCRIPTION
## Summary
- Fixes 3-point arc in `SceneStrip` and `PlayCard` thumbnails
- Changed SVG arc flags from `large-arc=1 sweep=0` → `large-arc=0 sweep=1`
- Previous flags selected the major CCW arc above the chord, which sweeps **below** the baseline (invisible), leaving only incorrect curved stubs near the corners
- Corrected flags select the minor CW arc centered near the basket, which bows upward correctly over the paint

## Test plan
- [ ] Scene strip thumbnails show a proper 3-point arc bowing upward over the basket
- [ ] Play card thumbnails show the same correct arc
- [ ] Corner straight lines remain straight (no curves at the sides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)