### PR TITLE
Improve defender token: smaller X, larger label

### DIFF
--- a/src/components/players/PlayerToken.tsx
+++ b/src/components/players/PlayerToken.tsx
@@ -218,15 +218,15 @@ export default function PlayerToken({
   }
 
   // Scale X-line extent and font proportionally to radius
-  const xSize = Math.round(radius * 7 / PLAYER_RADIUS);
+  const xSize = Math.round(radius * 5 / PLAYER_RADIUS);
   const scaledStrokeWidth = Math.max(1.5, strokeWidth * radius / PLAYER_RADIUS);
 
   // Shrink font for long names so they fit inside the token
-  const baseFontSize = Math.max(6, Math.round((isOffense ? 11 : 9) * radius / PLAYER_RADIUS));
+  const baseFontSize = Math.max(6, Math.round(11 * radius / PLAYER_RADIUS));
   const fontSize = label.length > 2 ? Math.max(5, baseFontSize - (label.length - 2) * 1.5) : baseFontSize;
 
   // Defense label sits above the X mark; scale the offset with radius
-  const textDy = isOffense ? 0 : -Math.round(radius * 9 / PLAYER_RADIUS);
+  const textDy = isOffense ? 0 : -Math.round(radius * 7 / PLAYER_RADIUS);
 
   return (
     <g


### PR DESCRIPTION
## Summary
- Reduces the X marker size (7→5 px at default radius) so it's less visually dominant
- Increases defense base font size to match offense (9→11 px) — "X3" labels are now clearly readable
- Reduces the vertical label offset proportionally so the label stays centred within the smaller X

## Test plan
- [ ] Defender tokens on court show a smaller X mark
- [ ] Position label (e.g. "X3") is larger and easy to read
- [ ] Long player names still fit inside the token circle
- [ ] Proportional scaling still works on mobile (smaller court)

🤖 Generated with [Claude Code](https://claude.com/claude-code)