### PR TITLE
Update docs to reflect current app state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# Claude Code — Project Instructions
+
+## Stack
+- Next.js 14 App Router, TypeScript, Tailwind CSS
+- Zustand store (`src/lib/store.ts`) for editor state
+- Firebase Auth + Firestore for persistence (`src/lib/db.ts`, `src/lib/firebase.ts`)
+- HTML5 Canvas court (`src/components/court/Court.tsx`) + SVG player overlay (`CourtWithPlayers.tsx`)
+- Vercel deployment — auto-deploys on merge to `master`
+- Live at: https://playbook-brown.vercel.app
+
+## Git Workflow
+- Trunk-based: branch from `master` → implement → rebase → squash-merge PR
+- Always rebase before creating PR; force push is expected
+- Use `fix/` prefix for bug fixes, `feature/` for new features
+
+## Key Conventions
+
+### Zustand store
+- `selectedSceneId` MUST always be set in sync with `currentPlay` — never set one without the other
+- Use `useStore.getState()` inside `useEffect` to read state without adding it to deps
+- Undo/redo wraps every store mutation — check `src/lib/store.ts` for the `withHistory` pattern
+
+### Coordinates
+- Court positions are normalized `[0, 1]` (x=0 left, x=1 right, y=0 half-court line, y=1 baseline)
+- Convert to pixels with `px = norm * courtWidth`, `py = norm * courtHeight`
+
+### SVG arcs in thumbnails (PlayCard, SceneStrip)
+- `large-arc=0, sweep=1` = minor CW arc = bows UPWARD (away from basket) ✓ — use for 3-point arc
+- `large-arc=0, sweep=0` = bows DOWNWARD (toward basket) — use for free-throw upper arc? No — check existing working arcs first
+- **Always verify SVG arcs in the browser** via `evaluate_script` + `take_screenshot` before pushing
+
+### Player tokens
+- `PlayerToken.tsx`: radius prop scales everything proportionally (X size, font, stroke)
+- Default radius = 18px; mobile uses `Math.max(10, courtWidth * 0.03)`
+- Defense: X mark size = `radius * 5 / 18`, label font same as offense (11px base)
+
+### EditorCourtArea infinite loop guard
+- Never put `currentPlay` in useEffect deps while also calling `setCurrentPlay` inside it
+- Use `useRef` initialized guard + `useStore.getState()` to break the cycle
+
+## Test Account
+- Email: test@playbook.com
+- Password: Test1234!
+- Team: מכבי קדימה (admin role)
+
+## Open Issues (as of 2026-02-21)
+- #77  GIF export
+- #128 Defender follow/guard assignment
+- #129 Multi-leg player paths
+- #130 Custom team colors
+- #132 Presentation mode
+- #133 Scene comments with threading

--- a/README.md
+++ b/README.md
@@ -4,12 +4,19 @@ A web-based basketball playbook application that allows coaches to diagram plays
 
 ## Features
 
-- Interactive court editor with standard basketball diagramming symbols
-- Multi-scene play creation with animated transitions
-- Shared team playbook accessible to all members
+- Interactive court editor with standard basketball diagramming symbols (movement, dribble, pass, screen, cut)
+- Multi-scene play creation with animated transitions and per-scene timing steps
+- Shared team playbook with search and category filters
 - Role-based permissions (admin, editor, viewer)
-- GIF export and share links for plays
-- Firebase authentication and real-time sync
+- Personal vs. team plays — create personal plays and promote them to the team playbook
+- Firebase authentication (email + Google) and real-time Firestore sync
+- Export: PDF (one page per scene), PNG (single scene)
+- Undo/redo, keyboard shortcuts, auto-save indicator
+- Mobile viewer mode (playback on phones, edit on desktop/tablet)
+
+### Live App
+
+https://playbook-brown.vercel.app
 
 ## Tech Stack
 

--- a/playbook-prd.md
+++ b/playbook-prd.md
@@ -368,43 +368,48 @@ The bottom panel has two levels:
 
 ## 7. MVP Scope vs. Future Enhancements
 
-### MVP (v1.0)
+### Shipped ✓
 - [x] Half court and full court
 - [x] 5 offensive + 5 defensive players, draggable
-- [x] Player display: numbers or names
+- [x] Player display: numbers, names, or position abbreviations
 - [x] Show/hide individual players per scene
 - [x] Ball placement and attachment
 - [x] Drawing tools: movement, dribble, pass, screen, cut
-- [x] Multi-scene plays with add/remove/reorder
+- [x] Multi-scene plays with add/remove/reorder/duplicate
 - [x] Timing groups within scenes (sequential action ordering)
 - [x] Animated transitions between scenes and within timing groups
-- [x] Playback controls (play, pause, step, speed)
-- [x] Play CRUD with title, category, tags
+- [x] Playback controls (play, pause, step, speed, loop)
+- [x] Play CRUD with title, description, category, court type
 - [x] Playbook grid view with thumbnails
-- [x] Filter and search plays
-- [x] Firebase auth (email + Google)
+- [x] Filter by category, search by title
+- [x] Firebase auth (email/password + Google)
 - [x] Team creation and invite link
 - [x] Role-based permissions (admin, editor, viewer)
-- [x] GIF export
-- [x] Share link for individual plays
+- [x] Personal vs. team plays (promote personal play to team)
+- [x] PDF export (one page per scene)
+- [x] PNG export (single scene)
+- [x] Undo/redo (50-step history)
+- [x] Keyboard shortcuts (tools, playback, scenes, ?)
+- [x] Auto-save with Firestore sync
+- [x] Mobile viewer mode (playback only on small screens)
+- [x] Responsive court (height-constrained, proportional player tokens)
 
-### v1.1
-- [ ] PDF export (scene per page)
-- [ ] PNG export (single scene)
-- [ ] Duplicate plays
-- [ ] Play description and per-scene notes
-- [ ] Presentation mode (full-screen)
-- [ ] MP4 video export
+### In Progress / Planned
+- [ ] GIF export of play animation (#77)
+- [ ] Presentation mode — full-screen playback for practice/projector (#132)
+- [ ] Scene comments with threading and resolve (#133) — Google Docs-style
+- [ ] Defender follow/guard assignment (#128)
+- [ ] Multi-leg player paths within a scene (#129)
+- [ ] Custom team colors for offense and defense (#130)
 
 ### v2.0 (Future)
 - [ ] 3x3 court support
 - [ ] Drill timer / practice plan builder
-- [ ] Collaborative real-time editing (multiple editors)
+- [ ] Collaborative real-time editing (multiple simultaneous editors)
 - [ ] Mobile-optimized editor (currently viewer-only on mobile)
 - [ ] Template plays library (common plays to start from)
 - [ ] Analytics: track which plays team members have viewed
 - [ ] Offline mode with full sync
-- [ ] Custom court colors / team branding
 - [ ] Voice-over recording on plays
 - [ ] Integration with video clips (attach game footage to plays)
 


### PR DESCRIPTION
## Summary
- **README**: Accurate feature list (PDF/PNG done, GIF not yet), added live URL
- **playbook-prd.md**: Full checklist of what's shipped vs. planned (replaces outdated v1.0/v1.1 split)
- **CLAUDE.md**: New file with project context, conventions, test account, and open issues — helps Claude Code orient quickly in future sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)