### PR TITLE
Fix #77: GIF export of play animation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "firebase": "^12.9.0",
+        "gifenc": "^1.0.3",
         "jspdf": "^4.2.0",
         "next": "14.2.35",
         "react": "^18",
@@ -3900,6 +3901,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/gifenc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
+      "integrity": "sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.3.10",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "firebase": "^12.9.0",
+    "gifenc": "^1.0.3",
     "jspdf": "^4.2.0",
     "next": "14.2.35",
     "react": "^18",

--- a/src/components/editor/ExportMenu.tsx
+++ b/src/components/editor/ExportMenu.tsx
@@ -1,43 +1,125 @@
 "use client";
 
 /**
- * ExportMenu — dropdown menu for scene export options.
+ * ExportMenu — dropdown menu for scene/play export options.
  *
  * Implements issue #79: PNG export of single scene.
+ * Implements issue #77: GIF export of play animation.
  *
- * Renders a "Export" button that opens a small dropdown with:
- *   - Export Image (PNG) — current scene, 2× resolution
- *
- * Future issues (#77, #80) will add GIF and PDF entries to this same menu.
+ * Renders an "Export" button that opens a small dropdown with:
+ *   - Export Image (PNG) — current scene, configurable resolution
+ *   - Export GIF       — full play animation, configurable speed + resolution
  */
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useStore, selectEditorScene } from "@/lib/store";
 import { exportSceneAsPNG, type ExportResolution } from "@/lib/exportPNG";
+import { exportPlayAsGIF, type GifResolution } from "@/lib/exportGIF";
 
 // ---------------------------------------------------------------------------
-// Resolution options
+// Resolution options (PNG)
 // ---------------------------------------------------------------------------
 
-const RESOLUTION_OPTIONS: { label: string; value: ExportResolution; description: string }[] = [
+const PNG_RESOLUTION_OPTIONS: { label: string; value: ExportResolution; description: string }[] = [
   { label: "Standard (1×)", value: "1x", description: "~800 × 752 px" },
   { label: "High (2×)", value: "2x", description: "~1600 × 1504 px" },
   { label: "Ultra (3×)", value: "3x", description: "~2400 × 2256 px" },
 ];
 
 // ---------------------------------------------------------------------------
+// Speed options (GIF)
+// ---------------------------------------------------------------------------
+
+const GIF_SPEED_OPTIONS: { label: string; value: number }[] = [
+  { label: "0.5×", value: 0.5 },
+  { label: "1×", value: 1 },
+  { label: "1.5×", value: 1.5 },
+  { label: "2×", value: 2 },
+];
+
+const GIF_RESOLUTION_OPTIONS: { label: string; value: GifResolution; description: string }[] = [
+  { label: "SD", value: "sd", description: "480 px — small file" },
+  { label: "HD", value: "hd", description: "800 px — sharper" },
+];
+
+// ---------------------------------------------------------------------------
+// Icon helpers
+// ---------------------------------------------------------------------------
+
+function DownloadIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path
+        d="M8 1v9M5 7l3 3 3-3M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function GifIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <rect x="1" y="3" width="14" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+      <path
+        d="M5 6l3 2.5L11 6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Progress bar sub-component
+// ---------------------------------------------------------------------------
+
+function ProgressBar({ fraction }: { fraction: number }) {
+  const pct = Math.round(fraction * 100);
+  return (
+    <div className="px-4 py-3">
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-xs font-medium text-gray-600">Rendering GIF…</span>
+        <span className="text-xs text-gray-500">{pct}%</span>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
+        <div
+          className="h-full rounded-full bg-blue-500 transition-all duration-150"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
+
+type ExportMode = "idle" | "png" | "gif";
 
 export default function ExportMenu() {
   const scene = useStore(selectEditorScene);
   const currentPlay = useStore((s) => s.currentPlay);
 
   const [open, setOpen] = useState(false);
-  const [exporting, setExporting] = useState(false);
-  const [selectedResolution, setSelectedResolution] = useState<ExportResolution>("2x");
+  const [exportMode, setExportMode] = useState<ExportMode>("idle");
+  const [gifProgress, setGifProgress] = useState(0);
+
+  // PNG settings
+  const [pngResolution, setPngResolution] = useState<ExportResolution>("2x");
+
+  // GIF settings
+  const [gifSpeed, setGifSpeed] = useState<number>(1);
+  const [gifResolution, setGifResolution] = useState<GifResolution>("sd");
 
   const menuRef = useRef<HTMLDivElement>(null);
+  const isExporting = exportMode !== "idle";
 
   // Close on outside click
   useEffect(() => {
@@ -63,61 +145,91 @@ export default function ExportMenu() {
 
   const handleExportPNG = useCallback(async () => {
     if (!scene) return;
-    setExporting(true);
+    setExportMode("png");
     setOpen(false);
     try {
       const title = currentPlay?.title ?? "play";
-      // Sanitise title for use as a filename
       const safeTitle = title.replace(/[^a-zA-Z0-9-_\s]/g, "").trim().replace(/\s+/g, "-");
       const sceneIndex = (currentPlay?.scenes.findIndex((s) => s.id === scene.id) ?? 0) + 1;
       const filename = `${safeTitle}-scene-${sceneIndex}`;
-      exportSceneAsPNG(scene, 800, selectedResolution, filename);
+      exportSceneAsPNG(scene, 800, pngResolution, filename);
     } finally {
-      // Small delay so the user sees the "Exporting…" state before it clears
-      setTimeout(() => setExporting(false), 500);
+      setTimeout(() => setExportMode("idle"), 500);
     }
-  }, [scene, currentPlay, selectedResolution]);
+  }, [scene, currentPlay, pngResolution]);
+
+  const handleExportGIF = useCallback(async () => {
+    if (!currentPlay) return;
+    setExportMode("gif");
+    setGifProgress(0);
+    setOpen(false);
+    try {
+      const title = currentPlay.title ?? "play";
+      const safeTitle = title.replace(/[^a-zA-Z0-9-_\s]/g, "").trim().replace(/\s+/g, "-") || "play";
+      await exportPlayAsGIF(currentPlay, safeTitle, {
+        speed: gifSpeed,
+        resolution: gifResolution,
+        onProgress: (fraction) => setGifProgress(fraction),
+      });
+    } finally {
+      setExportMode("idle");
+      setGifProgress(0);
+    }
+  }, [currentPlay, gifSpeed, gifResolution]);
 
   return (
     <div ref={menuRef} className="relative">
       <button
         className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
         onClick={() => setOpen((v) => !v)}
-        disabled={exporting || !scene}
+        disabled={isExporting || !scene}
         aria-haspopup="true"
         aria-expanded={open}
       >
-        {exporting ? "Exporting…" : "Export"}
+        {exportMode === "png"
+          ? "Exporting…"
+          : exportMode === "gif"
+            ? `GIF ${Math.round(gifProgress * 100)}%`
+            : "Export"}
       </button>
 
-      {open && (
+      {/* GIF progress — shown below the button when not in dropdown */}
+      {exportMode === "gif" && (
+        <div className="absolute right-0 top-full z-50 mt-1 w-56 rounded-lg border border-gray-200 bg-white shadow-lg">
+          <ProgressBar fraction={gifProgress} />
+        </div>
+      )}
+
+      {open && !isExporting && (
         <div
-          className="absolute right-0 top-full z-50 mt-1 w-64 rounded-lg border border-gray-200 bg-white shadow-lg"
+          className="absolute right-0 top-full z-50 mt-1 w-72 rounded-lg border border-gray-200 bg-white shadow-lg"
           role="menu"
           aria-label="Export options"
         >
-          {/* Header */}
+          {/* ---------------------------------------------------------------- */}
+          {/* PNG section                                                       */}
+          {/* ---------------------------------------------------------------- */}
           <div className="border-b border-gray-100 px-4 py-2.5">
             <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">
               Export Scene
             </p>
           </div>
 
-          {/* Resolution picker */}
+          {/* PNG resolution picker */}
           <div className="px-4 py-3">
-            <p className="mb-2 text-xs font-medium text-gray-600">Resolution</p>
+            <p className="mb-2 text-xs font-medium text-gray-600">PNG Resolution</p>
             <div className="flex flex-col gap-1.5">
-              {RESOLUTION_OPTIONS.map((opt) => (
+              {PNG_RESOLUTION_OPTIONS.map((opt) => (
                 <label
                   key={opt.value}
                   className="flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-gray-50"
                 >
                   <input
                     type="radio"
-                    name="export-resolution"
+                    name="export-png-resolution"
                     value={opt.value}
-                    checked={selectedResolution === opt.value}
-                    onChange={() => setSelectedResolution(opt.value)}
+                    checked={pngResolution === opt.value}
+                    onChange={() => setPngResolution(opt.value)}
                     className="accent-blue-600"
                   />
                   <span className="flex-1 text-sm text-gray-700">{opt.label}</span>
@@ -127,11 +239,8 @@ export default function ExportMenu() {
             </div>
           </div>
 
-          {/* Divider */}
-          <div className="border-t border-gray-100" />
-
-          {/* Export PNG action */}
-          <div className="p-2">
+          {/* PNG export button */}
+          <div className="border-t border-gray-100 p-2">
             <button
               className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700"
               role="menuitem"
@@ -139,81 +248,93 @@ export default function ExportMenu() {
               disabled={!scene}
             >
               <span className="flex h-8 w-8 items-center justify-center rounded-md bg-blue-100 text-blue-600">
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M8 1v9M5 7l3 3 3-3M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
+                <DownloadIcon />
               </span>
               <span>
                 <span className="block font-medium">Export as PNG</span>
                 <span className="block text-xs text-gray-500">
-                  Current scene · {selectedResolution} resolution
+                  Current scene · {pngResolution} resolution
                 </span>
               </span>
             </button>
           </div>
 
-          {/* Future items placeholder */}
+          {/* ---------------------------------------------------------------- */}
+          {/* GIF section                                                       */}
+          {/* ---------------------------------------------------------------- */}
+          <div className="border-t border-gray-200 px-4 py-2.5">
+            <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+              Export Play Animation
+            </p>
+          </div>
+
+          {/* GIF speed + resolution */}
+          <div className="px-4 py-3">
+            <div className="mb-3">
+              <p className="mb-1.5 text-xs font-medium text-gray-600">Playback Speed</p>
+              <div className="flex gap-1.5">
+                {GIF_SPEED_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => setGifSpeed(opt.value)}
+                    aria-pressed={gifSpeed === opt.value}
+                    className={[
+                      "rounded px-2.5 py-1 text-xs font-medium transition-colors",
+                      gifSpeed === opt.value
+                        ? "bg-blue-100 text-blue-700"
+                        : "bg-gray-100 text-gray-600 hover:bg-gray-200",
+                    ].join(" ")}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <p className="mb-1.5 text-xs font-medium text-gray-600">Resolution</p>
+              <div className="flex gap-1.5">
+                {GIF_RESOLUTION_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => setGifResolution(opt.value)}
+                    aria-pressed={gifResolution === opt.value}
+                    title={opt.description}
+                    className={[
+                      "rounded px-2.5 py-1 text-xs font-medium transition-colors",
+                      gifResolution === opt.value
+                        ? "bg-blue-100 text-blue-700"
+                        : "bg-gray-100 text-gray-600 hover:bg-gray-200",
+                    ].join(" ")}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+              <p className="mt-1 text-xs text-gray-400">
+                {GIF_RESOLUTION_OPTIONS.find((o) => o.value === gifResolution)?.description}
+              </p>
+            </div>
+          </div>
+
+          {/* GIF export button */}
           <div className="border-t border-gray-100 p-2">
             <button
-              className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm text-gray-400"
-              disabled
-              title="Coming soon"
+              className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm text-gray-700 hover:bg-green-50 hover:text-green-700"
+              role="menuitem"
+              onClick={handleExportGIF}
+              disabled={!currentPlay}
             >
-              <span className="flex h-8 w-8 items-center justify-center rounded-md bg-gray-100 text-gray-400">
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  aria-hidden="true"
-                >
-                  <rect x="1" y="3" width="14" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
-                  <path d="M5 6l3 2.5L11 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
+              <span className="flex h-8 w-8 items-center justify-center rounded-md bg-green-100 text-green-600">
+                <GifIcon />
               </span>
               <span>
                 <span className="block font-medium">Export as GIF</span>
-                <span className="block text-xs">Coming soon</span>
-              </span>
-            </button>
-            <button
-              className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm text-gray-400"
-              disabled
-              title="Coming soon"
-            >
-              <span className="flex h-8 w-8 items-center justify-center rounded-md bg-gray-100 text-gray-400">
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M3 1h7l3 3v10a1 1 0 01-1 1H3a1 1 0 01-1-1V2a1 1 0 011-1z"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path d="M10 1v3h3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </span>
-              <span>
-                <span className="block font-medium">Export as PDF</span>
-                <span className="block text-xs">Coming soon</span>
+                <span className="block text-xs text-gray-500">
+                  All {currentPlay?.scenes.length ?? 0} scene
+                  {(currentPlay?.scenes.length ?? 0) !== 1 ? "s" : ""} · {gifSpeed}× speed ·{" "}
+                  {gifResolution.toUpperCase()}
+                </span>
               </span>
             </button>
           </div>

--- a/src/lib/exportGIF.ts
+++ b/src/lib/exportGIF.ts
@@ -1,0 +1,683 @@
+"use client";
+
+/**
+ * GIF export utility — renders the full play animation as an animated GIF.
+ *
+ * Implements issue #77: GIF export of play animation.
+ *
+ * Approach:
+ *   1. For each scene in the play, for each timing step within that scene,
+ *      render one (or more) canvas frames.
+ *   2. Each frame shows the court + player positions + all annotations that
+ *      are visible at that point in the animation (cumulative reveal).
+ *   3. Encode the frames into an animated GIF using the `gifenc` library
+ *      (pure-JS, no workers needed, great for flat vector graphics).
+ *   4. Optionally render a brief "hold" frame between scenes to give the
+ *      viewer a moment to read the diagram before the next scene starts.
+ *   5. Trigger a browser download of the resulting GIF blob.
+ *
+ * Frame timing:
+ *   - Each step frame duration = timingGroup.duration / speedMultiplier.
+ *   - A hold frame of SCENE_HOLD_MS is inserted between scenes.
+ *   - At the last scene, a longer FINAL_HOLD_MS hold closes the animation.
+ *
+ * Resolution:
+ *   - SD: 480 px wide  (suitable for messaging apps, keeps file size small)
+ *   - HD: 800 px wide  (sharper, larger file)
+ *
+ * Color depth:
+ *   - GIF supports a maximum of 256 colors. We quantize to 128 colors which
+ *     balances quality and file size for this flat-color illustration style.
+ *
+ * Progress callback:
+ *   - `onProgress(fraction)` is called after each frame is encoded so the UI
+ *     can display a progress bar (fraction in [0, 1]).
+ */
+
+import { GIFEncoder, quantize, applyPalette } from "gifenc";
+import type { Play, Scene, Annotation } from "./types";
+import {
+  COURT_ASPECT_RATIO,
+  BASKET_X,
+  BASKET_Y,
+  BASKET_RADIUS,
+  BACKBOARD_Y,
+  BACKBOARD_HALF_WIDTH,
+  LANE_LEFT,
+  LANE_RIGHT,
+  LANE_TOP,
+  CORNER_THREE_Y,
+  CORNER_THREE_LEFT_X,
+  CORNER_THREE_RIGHT_X,
+  FT_CIRCLE_CENTER_X,
+  FT_CIRCLE_CENTER_Y,
+  CENTRE_CIRCLE_RADIUS,
+} from "@/components/court/courtDimensions";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Brief pause between scenes (ms). */
+const SCENE_HOLD_MS = 400;
+
+/** Longer pause at the very end of the animation before it loops (ms). */
+const FINAL_HOLD_MS = 1200;
+
+/** Maximum GIF palette size (256 is the GIF spec limit). */
+const MAX_COLORS = 128;
+
+// ---------------------------------------------------------------------------
+// Court colours (must match exportPNG.ts)
+// ---------------------------------------------------------------------------
+
+const COLOR_COURT = "#F0C878";
+const COLOR_PAINT = "#E07B39";
+const COLOR_LINE = "#FFFFFF";
+const COLOR_LINE_WIDTH_PX = 2;
+
+// ---------------------------------------------------------------------------
+// Court drawing (copy of the logic in exportPNG.ts — kept in sync)
+// ---------------------------------------------------------------------------
+
+function drawCourtOnCanvas(canvas: HTMLCanvasElement): void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  const W = canvas.width;
+  const H = canvas.height;
+
+  const cx = (nx: number) => nx * W;
+  const cy = (ny: number) => ny * H;
+  const rx = (nr: number) => nr * W;
+  const scaleY = H / W;
+
+  ctx.clearRect(0, 0, W, H);
+
+  // 1. Court background
+  ctx.fillStyle = COLOR_COURT;
+  ctx.fillRect(0, 0, W, H);
+
+  // 2. Paint
+  ctx.fillStyle = COLOR_PAINT;
+  ctx.fillRect(cx(LANE_LEFT), cy(LANE_TOP), cx(LANE_RIGHT) - cx(LANE_LEFT), cy(1) - cy(LANE_TOP));
+
+  ctx.strokeStyle = COLOR_LINE;
+  ctx.lineWidth = COLOR_LINE_WIDTH_PX;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+
+  // 3. Court boundary
+  ctx.strokeRect(0, 0, W, H);
+
+  // 4. Half-court line
+  ctx.beginPath();
+  ctx.moveTo(0, cy(0));
+  ctx.lineTo(W, cy(0));
+  ctx.stroke();
+
+  // 5. Half-court centre-circle arc
+  ctx.save();
+  ctx.scale(1, scaleY);
+  ctx.beginPath();
+  ctx.arc(cx(0.5), 0, rx(CENTRE_CIRCLE_RADIUS), 0, Math.PI);
+  ctx.restore();
+  ctx.stroke();
+
+  // 6. Three-point arc
+  const FT_PER_PX_X = 50 / W;
+  const FT_PER_PX_Y = 47 / H;
+
+  ctx.save();
+  ctx.scale(1 / FT_PER_PX_X, 1 / FT_PER_PX_Y);
+
+  const basketX_ft = BASKET_X * 50;
+  const basketY_ft = BASKET_Y * 47;
+  const cornerY_ft = CORNER_THREE_Y * 47;
+  const leftCornerX_ft = CORNER_THREE_LEFT_X * 50;
+  const rightCornerX_ft = CORNER_THREE_RIGHT_X * 50;
+
+  ctx.strokeStyle = COLOR_LINE;
+  ctx.lineWidth = COLOR_LINE_WIDTH_PX * FT_PER_PX_X;
+
+  ctx.beginPath();
+  ctx.moveTo(leftCornerX_ft, 47);
+  ctx.lineTo(leftCornerX_ft, cornerY_ft);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.moveTo(rightCornerX_ft, 47);
+  ctx.lineTo(rightCornerX_ft, cornerY_ft);
+  ctx.stroke();
+
+  const arcAngleLeftCorner = Math.atan2(cornerY_ft - basketY_ft, leftCornerX_ft - basketX_ft);
+  const arcAngleRightCorner = Math.atan2(cornerY_ft - basketY_ft, rightCornerX_ft - basketX_ft);
+
+  ctx.beginPath();
+  ctx.arc(basketX_ft, basketY_ft, 23.75, arcAngleRightCorner, arcAngleLeftCorner, true);
+  ctx.stroke();
+
+  // 7. Restricted area arc
+  ctx.beginPath();
+  ctx.arc(basketX_ft, basketY_ft, 4, Math.PI, 0, false);
+  ctx.stroke();
+
+  ctx.restore();
+
+  // 8. Paint lane outline
+  ctx.beginPath();
+  ctx.strokeRect(cx(LANE_LEFT), cy(LANE_TOP), cx(LANE_RIGHT) - cx(LANE_LEFT), cy(1) - cy(LANE_TOP));
+
+  // 9. Free-throw line
+  ctx.beginPath();
+  ctx.moveTo(cx(LANE_LEFT), cy(FT_CIRCLE_CENTER_Y));
+  ctx.lineTo(cx(LANE_RIGHT), cy(FT_CIRCLE_CENTER_Y));
+  ctx.stroke();
+
+  // 10. Free-throw circle
+  ctx.save();
+  ctx.scale(1 / FT_PER_PX_X, 1 / FT_PER_PX_Y);
+
+  const ftCenterX_ft = FT_CIRCLE_CENTER_X * 50;
+  const ftCenterY_ft = FT_CIRCLE_CENTER_Y * 47;
+  const ftRadius_ft = 6;
+
+  ctx.strokeStyle = COLOR_LINE;
+  ctx.lineWidth = COLOR_LINE_WIDTH_PX * FT_PER_PX_X;
+
+  ctx.beginPath();
+  ctx.arc(ftCenterX_ft, ftCenterY_ft, ftRadius_ft, Math.PI, 0, false);
+  ctx.stroke();
+
+  ctx.setLineDash([0.75, 0.75]);
+  ctx.beginPath();
+  ctx.arc(ftCenterX_ft, ftCenterY_ft, ftRadius_ft, 0, Math.PI, false);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  ctx.restore();
+
+  // 11. Backboard
+  ctx.beginPath();
+  ctx.moveTo(cx(BASKET_X - BACKBOARD_HALF_WIDTH), cy(BACKBOARD_Y));
+  ctx.lineTo(cx(BASKET_X + BACKBOARD_HALF_WIDTH), cy(BACKBOARD_Y));
+  ctx.stroke();
+
+  // 12. Basket / rim
+  ctx.save();
+  ctx.scale(1, scaleY);
+  ctx.beginPath();
+  ctx.arc(cx(BASKET_X), cy(BASKET_Y) / scaleY, rx(BASKET_RADIUS), 0, Math.PI * 2);
+  ctx.strokeStyle = COLOR_LINE;
+  ctx.stroke();
+  ctx.restore();
+}
+
+// ---------------------------------------------------------------------------
+// Player drawing (mirrors exportPNG.ts)
+// ---------------------------------------------------------------------------
+
+const PLAYER_RADIUS = 18;
+const COLOR_OFFENSE_FILL = "#E07B39";
+const COLOR_OFFENSE_STROKE = "#FFFFFF";
+const COLOR_DEFENSE_FILL = "#FFFFFF";
+const COLOR_DEFENSE_STROKE = "#1E3A5F";
+const COLOR_TEXT_OFFENSE = "#FFFFFF";
+const COLOR_TEXT_DEFENSE = "#1E3A5F";
+
+function drawPlayer(
+  ctx: CanvasRenderingContext2D,
+  side: "offense" | "defense",
+  position: number,
+  px: number,
+  py: number,
+  scale: number,
+): void {
+  const r = PLAYER_RADIUS * scale;
+  const isOffense = side === "offense";
+
+  ctx.save();
+  ctx.globalAlpha = 0.25;
+  ctx.fillStyle = "#000000";
+  ctx.beginPath();
+  ctx.arc(px + scale, py + 2 * scale, r, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+
+  ctx.beginPath();
+  ctx.arc(px, py, r, 0, Math.PI * 2);
+  ctx.fillStyle = isOffense ? COLOR_OFFENSE_FILL : COLOR_DEFENSE_FILL;
+  ctx.fill();
+  ctx.strokeStyle = isOffense ? COLOR_OFFENSE_STROKE : COLOR_DEFENSE_STROKE;
+  ctx.lineWidth = (isOffense ? 2 : 2.5) * scale;
+  ctx.stroke();
+
+  if (!isOffense) {
+    const xSize = 7 * scale;
+    ctx.strokeStyle = COLOR_DEFENSE_STROKE;
+    ctx.lineWidth = 2.5 * scale;
+    ctx.lineCap = "round";
+    ctx.beginPath();
+    ctx.moveTo(px - xSize, py - xSize);
+    ctx.lineTo(px + xSize, py + xSize);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(px + xSize, py - xSize);
+    ctx.lineTo(px - xSize, py + xSize);
+    ctx.stroke();
+  }
+
+  const label = isOffense
+    ? ({ 1: "PG", 2: "SG", 3: "SF", 4: "PF", 5: "C" }[position] ?? String(position))
+    : `X${position}`;
+  const baseFontSize = isOffense ? 11 : 9;
+  const fontSize =
+    (label.length > 2
+      ? Math.max(6, baseFontSize - (label.length - 2) * 1.5)
+      : baseFontSize) * scale;
+
+  ctx.fillStyle = isOffense ? COLOR_TEXT_OFFENSE : COLOR_TEXT_DEFENSE;
+  ctx.font = `700 ${fontSize}px system-ui, sans-serif`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  const dyOffset = isOffense ? 0 : -9 * scale;
+  ctx.fillText(label, px, py + dyOffset);
+}
+
+// ---------------------------------------------------------------------------
+// Ball drawing (mirrors exportPNG.ts)
+// ---------------------------------------------------------------------------
+
+const BALL_RADIUS = 12;
+const COLOR_BALL = "#E05C00";
+const COLOR_BALL_HIGHLIGHT = "#F47B2A";
+const COLOR_SEAM = "#FFFFFF";
+const BALL_ATTACH_OFFSET_Y = -22;
+
+function drawBall(ctx: CanvasRenderingContext2D, px: number, py: number, scale: number): void {
+  const r = BALL_RADIUS * scale;
+
+  ctx.save();
+  ctx.globalAlpha = 0.3;
+  ctx.fillStyle = "#000000";
+  ctx.beginPath();
+  ctx.arc(px + scale, py + 2 * scale, r, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+
+  ctx.beginPath();
+  ctx.arc(px, py, r, 0, Math.PI * 2);
+  ctx.fillStyle = COLOR_BALL;
+  ctx.fill();
+
+  ctx.beginPath();
+  ctx.moveTo(px - r * 0.5, py - r * 0.6);
+  ctx.arc(px, py, r * 0.7, Math.PI + 0.6, Math.PI * 2 - 0.4, false);
+  ctx.strokeStyle = COLOR_BALL_HIGHLIGHT;
+  ctx.lineWidth = 1.5 * scale;
+  ctx.lineCap = "round";
+  ctx.globalAlpha = 0.5;
+  ctx.stroke();
+  ctx.globalAlpha = 1;
+
+  const vPath = new Path2D(
+    `M ${px} ${py - r} C ${px + r * 0.55} ${py - r * 0.5} ${px + r * 0.55} ${py + r * 0.5} ${px} ${py + r}`,
+  );
+  ctx.strokeStyle = COLOR_SEAM;
+  ctx.lineWidth = 1.2 * scale;
+  ctx.lineCap = "round";
+  ctx.stroke(vPath);
+
+  const hPath = new Path2D(
+    `M ${px - r} ${py} C ${px - r * 0.5} ${py + r * 0.4} ${px + r * 0.5} ${py + r * 0.4} ${px + r} ${py}`,
+  );
+  ctx.stroke(hPath);
+}
+
+// ---------------------------------------------------------------------------
+// Annotation drawing (mirrors exportPNG.ts)
+// ---------------------------------------------------------------------------
+
+function arrowHeadPoints(
+  x2: number,
+  y2: number,
+  x1: number,
+  y1: number,
+  size: number,
+): [number, number][] | null {
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const len = Math.sqrt(dx * dx + dy * dy);
+  if (len < 1) return null;
+  const ux = dx / len;
+  const uy = dy / len;
+  const perpX = -uy;
+  const perpY = ux;
+  const w = size * 0.45;
+  return [
+    [x2, y2],
+    [x2 - ux * size + perpX * w, y2 - uy * size + perpY * w],
+    [x2 - ux * size - perpX * w, y2 - uy * size - perpY * w],
+  ];
+}
+
+function drawArrowHead(
+  ctx: CanvasRenderingContext2D,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  size: number,
+  color: string,
+): void {
+  const pts = arrowHeadPoints(x2, y2, x1, y1, size);
+  if (!pts) return;
+  ctx.beginPath();
+  ctx.moveTo(pts[0][0], pts[0][1]);
+  ctx.lineTo(pts[1][0], pts[1][1]);
+  ctx.lineTo(pts[2][0], pts[2][1]);
+  ctx.closePath();
+  ctx.fillStyle = color;
+  ctx.fill();
+}
+
+function drawAnnotation(
+  ctx: CanvasRenderingContext2D,
+  ann: Annotation,
+  scale: number,
+): void {
+  const { from, to, type } = ann;
+  const arrowSize = 12 * scale;
+
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+
+  if (type === "movement") {
+    ctx.beginPath();
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
+    ctx.strokeStyle = "#1E3A5F";
+    ctx.lineWidth = 2.5 * scale;
+    ctx.stroke();
+    drawArrowHead(ctx, from.x, from.y, to.x, to.y, arrowSize, "#1E3A5F");
+    return;
+  }
+
+  if (type === "dribble") {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const zigCount = Math.max(2, Math.round(len / (18 * scale)));
+    ctx.beginPath();
+    for (let i = 0; i <= zigCount; i++) {
+      const t = i / zigCount;
+      const mx = from.x + dx * t;
+      const my = from.y + dy * t;
+      const perp = i % 2 === 0 ? 6 * scale : -6 * scale;
+      const px2 = len > 0 ? (-dy / len) * perp : 0;
+      const py2 = len > 0 ? (dx / len) * perp : 0;
+      if (i === 0) ctx.moveTo(mx + px2, my + py2);
+      else ctx.lineTo(mx + px2, my + py2);
+    }
+    ctx.strokeStyle = "#1E3A5F";
+    ctx.lineWidth = 2.5 * scale;
+    ctx.stroke();
+    drawArrowHead(ctx, from.x, from.y, to.x, to.y, arrowSize, "#1E3A5F");
+    return;
+  }
+
+  if (type === "pass") {
+    ctx.beginPath();
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
+    ctx.strokeStyle = "#059669";
+    ctx.lineWidth = 2 * scale;
+    ctx.stroke();
+    drawArrowHead(ctx, from.x, from.y, to.x, to.y, arrowSize, "#059669");
+    return;
+  }
+
+  if (type === "screen") {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const perpX = len > 0 ? (-dy / len) * 10 * scale : 0;
+    const perpY = len > 0 ? (dx / len) * 10 * scale : 0;
+    ctx.beginPath();
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
+    ctx.strokeStyle = "#7C3AED";
+    ctx.lineWidth = 2.5 * scale;
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(to.x + perpX, to.y + perpY);
+    ctx.lineTo(to.x - perpX, to.y - perpY);
+    ctx.lineWidth = 3 * scale;
+    ctx.stroke();
+    return;
+  }
+
+  if (type === "cut") {
+    ctx.beginPath();
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
+    ctx.strokeStyle = "#DC2626";
+    ctx.lineWidth = 2.5 * scale;
+    ctx.setLineDash([7 * scale, 5 * scale]);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    drawArrowHead(ctx, from.x, from.y, to.x, to.y, arrowSize, "#DC2626");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Frame rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a single animation frame onto the given canvas.
+ *
+ * @param canvas    Destination canvas (already sized to W × H).
+ * @param scene     Scene data (player positions, ball, timing groups).
+ * @param visibleAnnotations  Annotations to draw on this frame (cumulative subset).
+ * @param width     Canvas width in px.
+ * @param height    Canvas height in px.
+ */
+function renderFrame(
+  canvas: HTMLCanvasElement,
+  scene: Scene,
+  visibleAnnotations: Annotation[],
+  width: number,
+  height: number,
+): void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  // Court background
+  drawCourtOnCanvas(canvas);
+
+  // Overlay: annotations + players + ball
+  ctx.save();
+
+  // Draw annotations (below players)
+  for (const ann of visibleAnnotations) {
+    drawAnnotation(ctx, ann, 1);
+  }
+
+  // Defense
+  for (const p of scene.players.defense) {
+    if (p.visible) {
+      drawPlayer(ctx, "defense", p.position, p.x * width, p.y * height, 1);
+    }
+  }
+
+  // Offense
+  for (const p of scene.players.offense) {
+    if (p.visible) {
+      drawPlayer(ctx, "offense", p.position, p.x * width, p.y * height, 1);
+    }
+  }
+
+  // Ball
+  const ball = scene.ball;
+  let ballPx = { x: ball.x * width, y: ball.y * height };
+  if (ball.attachedTo) {
+    const pool =
+      ball.attachedTo.side === "offense" ? scene.players.offense : scene.players.defense;
+    const holder = pool.find((p) => p.position === ball.attachedTo!.position);
+    if (holder) {
+      ballPx = { x: holder.x * width, y: holder.y * height + BALL_ATTACH_OFFSET_Y };
+    }
+  }
+  drawBall(ctx, ballPx.x, ballPx.y, 1);
+
+  ctx.restore();
+}
+
+// ---------------------------------------------------------------------------
+// GIF frame encoding helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract RGBA pixel data from a canvas and encode one GIF frame.
+ */
+function encodeFrame(
+  encoder: ReturnType<typeof GIFEncoder>,
+  canvas: HTMLCanvasElement,
+  delayMs: number,
+  isFirst: boolean,
+): void {
+  const ctx = canvas.getContext("2d")!;
+  const { width, height } = canvas;
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const rgba = new Uint8Array(imageData.data.buffer);
+
+  const palette = quantize(rgba, MAX_COLORS);
+  const index = applyPalette(rgba, palette);
+
+  encoder.writeFrame(index, width, height, {
+    palette,
+    delay: delayMs,
+    repeat: 0, // infinite loop
+    first: isFirst,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export type GifResolution = "sd" | "hd";
+
+export interface ExportGIFOptions {
+  /** Playback speed multiplier. Higher = shorter frame durations. Default 1. */
+  speed?: number;
+  /** Output resolution preset. Default "sd". */
+  resolution?: GifResolution;
+  /** Called with progress in [0, 1] after each encoded frame. */
+  onProgress?: (fraction: number) => void;
+}
+
+const RESOLUTION_WIDTH: Record<GifResolution, number> = {
+  sd: 480,
+  hd: 800,
+};
+
+/**
+ * Export the given play as an animated GIF and trigger a browser download.
+ *
+ * @param play      The play to export (must have at least one scene).
+ * @param filename  Download filename without extension.
+ * @param options   Speed, resolution, progress callback.
+ */
+export async function exportPlayAsGIF(
+  play: Play,
+  filename: string = "play",
+  options: ExportGIFOptions = {},
+): Promise<void> {
+  const { speed = 1, resolution = "sd", onProgress } = options;
+
+  const width = RESOLUTION_WIDTH[resolution];
+  const height = Math.round(width / COURT_ASPECT_RATIO);
+
+  // Allocate a single offscreen canvas reused for every frame.
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+
+  const encoder = GIFEncoder();
+
+  // Sort scenes by order
+  const scenes = [...play.scenes].sort((a, b) => a.order - b.order);
+
+  // Pre-compute total frame count for progress reporting
+  let totalFrames = 0;
+  for (const scene of scenes) {
+    totalFrames += scene.timingGroups.length; // one frame per step
+    totalFrames += 1; // hold frame between scenes
+  }
+  let framesEncoded = 0;
+
+  let isFirst = true;
+
+  for (let si = 0; si < scenes.length; si++) {
+    const scene = scenes[si];
+    const sortedGroups = [...scene.timingGroups].sort((a, b) => a.step - b.step);
+
+    // Cumulative annotation list — we reveal one timing step at a time
+    const cumulativeAnnotations: Annotation[] = [];
+
+    for (let gi = 0; gi < sortedGroups.length; gi++) {
+      const group = sortedGroups[gi];
+
+      // Add this step's annotations to the running cumulative list
+      cumulativeAnnotations.push(...group.annotations);
+
+      // Duration for this frame: respect speed and clamp to reasonable range
+      const rawDuration = group.duration / speed;
+      // GIF delay is in 10ms units; minimum 10ms (100fps), cap at 10s
+      const delayMs = Math.min(Math.max(Math.round(rawDuration), 10), 10000);
+
+      renderFrame(canvas, scene, cumulativeAnnotations, width, height);
+      encodeFrame(encoder, canvas, delayMs, isFirst);
+      isFirst = false;
+
+      framesEncoded += 1;
+      onProgress?.(framesEncoded / totalFrames);
+
+      // Yield to keep the UI responsive between frames
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
+
+    // Hold frame between scenes (or longer final hold at the last scene)
+    const holdMs = si === scenes.length - 1 ? FINAL_HOLD_MS : SCENE_HOLD_MS;
+    const holdDelay = Math.round(holdMs / speed);
+
+    // Re-render with all annotations of this scene visible for the hold
+    renderFrame(canvas, scene, cumulativeAnnotations, width, height);
+    encodeFrame(encoder, canvas, holdDelay, isFirst);
+    isFirst = false;
+
+    framesEncoded += 1;
+    onProgress?.(framesEncoded / totalFrames);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+
+  encoder.finish();
+  // encoder.bytes() returns a Uint8Array whose .buffer is typed as ArrayBufferLike
+  // (could be SharedArrayBuffer). Copy to a plain Uint8Array backed by a fresh
+  // ArrayBuffer so that the Blob constructor accepts it without TS errors.
+  const rawBytes = encoder.bytes();
+  const safeBytes = new Uint8Array(rawBytes);
+  const blob = new Blob([safeBytes], { type: "image/gif" });
+
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${filename}.gif`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/src/types/gifenc.d.ts
+++ b/src/types/gifenc.d.ts
@@ -1,0 +1,76 @@
+/**
+ * Minimal type declarations for the gifenc package (no official @types).
+ * Reference: https://github.com/mattdesl/gifenc
+ */
+
+declare module "gifenc" {
+  /** A single palette entry: [r, g, b] or [r, g, b, a] */
+  export type PaletteColor = [number, number, number] | [number, number, number, number];
+
+  export interface WriteFrameOptions {
+    /** Palette for this frame (required for the first frame). */
+    palette?: PaletteColor[];
+    /** Frame delay in milliseconds. */
+    delay?: number;
+    /** Repeat count: 0 = infinite, -1 = no repeat. Default 0. */
+    repeat?: number;
+    /** Whether this is the first frame (auto-writes header). */
+    first?: boolean;
+    /** Enable transparency. */
+    transparent?: boolean;
+    /** Index in the palette to use as transparent color. */
+    transparentIndex?: number;
+    /** Dispose method. */
+    dispose?: number;
+    /** Color depth (bits). Default 8. */
+    colorDepth?: number;
+  }
+
+  export interface GIFEncoderInstance {
+    reset(): void;
+    finish(): void;
+    bytes(): Uint8Array;
+    bytesView(): Uint8Array;
+    readonly buffer: ArrayBuffer;
+    writeHeader(): void;
+    writeFrame(
+      indexedPixels: Uint8Array,
+      width: number,
+      height: number,
+      options?: WriteFrameOptions,
+    ): void;
+  }
+
+  export interface GIFEncoderOptions {
+    initialCapacity?: number;
+    auto?: boolean;
+  }
+
+  export function GIFEncoder(options?: GIFEncoderOptions): GIFEncoderInstance;
+
+  /**
+   * Quantize RGBA pixel data down to at most `maxColors` palette entries.
+   */
+  export function quantize(
+    rgba: Uint8Array | Uint8ClampedArray,
+    maxColors: number,
+    options?: {
+      format?: "rgb565" | "rgb444" | "rgba4444";
+      oneBitAlpha?: boolean;
+      clearAlpha?: boolean;
+      clearAlphaColor?: number;
+      clearAlphaThreshold?: number;
+    },
+  ): PaletteColor[];
+
+  /**
+   * Map each RGBA pixel to the nearest palette index.
+   */
+  export function applyPalette(
+    rgba: Uint8Array | Uint8ClampedArray,
+    palette: PaletteColor[],
+    format?: "rgb565" | "rgb444" | "rgba4444",
+  ): Uint8Array;
+
+  export default GIFEncoder;
+}


### PR DESCRIPTION
## Summary

Implements issue #77 — animated GIF export of the full play.

- **`src/lib/exportGIF.ts`** — new pure-client-side GIF renderer:
  - Sorts scenes by order, iterates timing steps within each scene
  - Renders cumulative annotations per frame (step 1 shows step-1 arrows; step 2 shows step-1 + step-2 arrows, etc.)
  - Inserts a 400ms hold frame between scenes, 1200ms at the end before looping
  - Uses `gifenc` (`quantize` + `applyPalette` + `GIFEncoder`) — no web workers, no server required
  - Configurable speed multiplier (0.5×/1×/1.5×/2×) and resolution (SD 480px / HD 800px)
  - Progress callback drives the UI progress bar
  - Court + player + ball + annotation drawing copied faithfully from `exportPNG.ts`

- **`src/types/gifenc.d.ts`** — TypeScript declarations for the untyped `gifenc` package

- **`src/components/editor/ExportMenu.tsx`** — replaces "Coming soon" GIF button with:
  - Speed selector (pill buttons: 0.5× 1× 1.5× 2×)
  - Resolution selector (SD / HD with file-size hint)
  - Active "Export as GIF" button with scene count summary
  - Inline progress bar that appears while encoding (% shown on Export button label too)

## How it works

Each GIF frame is rendered to a single offscreen `<canvas>` reused across all frames. After drawing, `ctx.getImageData()` gives raw RGBA pixels, which `gifenc` quantizes to ≤128 palette entries and LZW-compresses. Frames are `setTimeout(0)` yielded between encoding to keep the browser responsive. The finished bytes are downloaded as a `.gif` file.

## Test plan

- [ ] Open a play with multiple scenes and annotations
- [ ] Click **Export** → verify two sections appear: "Export Scene" (PNG) and "Export Play Animation" (GIF)
- [ ] Change speed to 0.5× and resolution to HD, then click **Export as GIF**
- [ ] Verify progress bar appears and increments
- [ ] Verify a `.gif` file downloads when encoding completes
- [ ] Open the GIF in a browser / messaging app and confirm it animates correctly across scenes with progressive annotation reveal
- [ ] Verify SD file size is well under 5MB for a typical 2–3 scene play
- [ ] Verify PNG export still works correctly (no regression)
- [ ] TypeScript: `npx tsc --noEmit` passes
- [ ] Build: `npm run build` succeeds

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)