### PR TITLE
Fix invite link for new users (#75)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,6 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -101,6 +101,18 @@ service cloud.firestore {
     }
 
     // -----------------------------------------------------------------------
+    // Invite documents (readable by any signed-in user, #75)
+    // Each document: invites/{inviteCode} → { teamId }
+    // Allows joinTeamByInviteCode to look up the teamId without querying
+    // the protected teams collection.
+    // -----------------------------------------------------------------------
+
+    match /invites/{inviteCode} {
+      allow read:  if isSignedIn();
+      allow write: if isSignedIn();
+    }
+
+    // -----------------------------------------------------------------------
     // Shared play tokens (public read-only, #78)
     // -----------------------------------------------------------------------
 

--- a/src/app/playbook/page.tsx
+++ b/src/app/playbook/page.tsx
@@ -21,6 +21,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useTeam } from "@/contexts/TeamContext";
 import { signOut } from "@/lib/auth";
 import { loadPlaysForUser, loadPlaysForTeam } from "@/lib/db";
+import { ensureInviteDoc } from "@/lib/team";
 import CreateTeamModal from "@/components/playbook/CreateTeamModal";
 
 const CATEGORY_FILTERS: { value: Category | "all"; label: string }[] = [
@@ -205,6 +206,8 @@ export default function PlaybookPage() {
                 {(role === "admin") && (
                   <button
                     onClick={() => {
+                      // Ensure invite doc exists for existing teams (backward compat)
+                      void ensureInviteDoc(team.inviteCode, team.id);
                       navigator.clipboard.writeText(
                         `${window.location.origin}/join/${team.inviteCode}`,
                       ).catch(() => {});


### PR DESCRIPTION
## Summary

- New users couldn't join a team via invite link — they saw "Missing or insufficient permissions" because `joinTeamByInviteCode` queried the `teams` collection, which Firestore rules block for non-members
- Adds a separate `/invites/{code}` collection (readable by any signed-in user) that maps each invite code → teamId
- `joinTeamByInviteCode` now reads `invites/{code}` to resolve the teamId, then fetches the team doc directly — no collection query needed
- `createTeam` writes the invite doc at creation time
- "Copy invite" button calls `ensureInviteDoc` on click for backward compatibility with teams created before this fix (lazy migration)
- Changed `updateDoc` → `setDoc+merge` for user doc in `joinTeamByInviteCode` — safe for brand-new accounts with no user document yet

## Firestore rules change

Added a new collection rule (already deployed separately):
```
match /invites/{inviteCode} {
  allow read:  if isSignedIn();
  allow write: if isSignedIn();
}
```

## Test plan

- [ ] Deploy Firestore rules (see note below)
- [ ] Create a new account with a fresh email
- [ ] As admin, click "Copy invite" to generate the invite link (this writes the invite doc for existing teams)
- [ ] Open the invite link in a private window as the new account → should land on `/playbook`
- [ ] Verify the new user appears as a viewer in the team
- [ ] New team creation should also work for new invites without needing the "Copy invite" workaround

> **Note:** The updated `firestore.rules` must be deployed to Firebase before this PR is merged. Run: `npx firebase-tools deploy --only firestore:rules` (or paste the rules into Firebase Console → Firestore → Rules).

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)