### PR TITLE
Fix #130: Custom team colors for offense and defense

### DIFF
--- a/src/app/play/[id]/EditorHeader.tsx
+++ b/src/app/play/[id]/EditorHeader.tsx
@@ -13,7 +13,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useStore } from "@/lib/store";
-import type { Category, CourtType } from "@/lib/types";
+import type { Category, CourtType, PlayColors } from "@/lib/types";
 import { exportPlayToPdf } from "@/lib/exportPdf";
 import { useAuth } from "@/contexts/AuthContext";
 import { createShareToken } from "@/lib/team";
@@ -38,6 +38,7 @@ export default function EditorHeader({ playId, children }: EditorHeaderProps) {
   const currentPlay = useStore((s) => s.currentPlay);
   const updatePlayInList = useStore((s) => s.updatePlayInList);
   const updatePlayMeta = useStore((s) => s.updatePlayMeta);
+  const updatePlayColors = useStore((s) => s.updatePlayColors);
 
   const title = currentPlay?.title ?? null;
 
@@ -83,11 +84,16 @@ export default function EditorHeader({ playId, children }: EditorHeaderProps) {
     }
   }
 
+  const DEFAULT_OFFENSE_COLOR = "#E07B39";
+  const DEFAULT_DEFENSE_COLOR = "#1E3A5F";
+
   const [showEdit, setShowEdit] = useState(false);
   const [editTitle, setEditTitle] = useState("");
   const [editDesc, setEditDesc] = useState("");
   const [editCategory, setEditCategory] = useState<Category>("offense");
   const [editCourtType, setEditCourtType] = useState<CourtType>("half");
+  const [editOffenseColor, setEditOffenseColor] = useState(DEFAULT_OFFENSE_COLOR);
+  const [editDefenseColor, setEditDefenseColor] = useState(DEFAULT_DEFENSE_COLOR);
   const [editError, setEditError] = useState("");
 
   const titleInputRef = useRef<HTMLInputElement>(null);
@@ -99,6 +105,8 @@ export default function EditorHeader({ playId, children }: EditorHeaderProps) {
     setEditDesc(currentPlay.description);
     setEditCategory(currentPlay.category);
     setEditCourtType(currentPlay.courtType);
+    setEditOffenseColor(currentPlay.colors?.offense ?? DEFAULT_OFFENSE_COLOR);
+    setEditDefenseColor(currentPlay.colors?.defense ?? DEFAULT_DEFENSE_COLOR);
     setEditError("");
     setShowEdit(true);
   }
@@ -132,10 +140,12 @@ export default function EditorHeader({ playId, children }: EditorHeaderProps) {
       return;
     }
     const patch = { title: trimmed, description: editDesc, category: editCategory, courtType: editCourtType };
+    const colors: PlayColors = { offense: editOffenseColor, defense: editDefenseColor };
     updatePlayMeta(patch);
+    updatePlayColors(colors);
     // Sync immediately to the plays list so the playbook grid reflects the update.
     if (currentPlay) {
-      updatePlayInList({ ...currentPlay, ...patch, updatedAt: new Date() });
+      updatePlayInList({ ...currentPlay, ...patch, colors, updatedAt: new Date() });
     }
     setShowEdit(false);
   }
@@ -375,7 +385,7 @@ export default function EditorHeader({ playId, children }: EditorHeaderProps) {
               </div>
 
               {/* Court type + Category row */}
-              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 24 }}>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 16 }}>
                 <div>
                   <label
                     htmlFor="edit-court-type"
@@ -435,6 +445,126 @@ export default function EditorHeader({ playId, children }: EditorHeaderProps) {
                       </option>
                     ))}
                   </select>
+                </div>
+              </div>
+
+              {/* Team colors row */}
+              <div style={{ marginBottom: 24 }}>
+                <p style={{ fontSize: 13, fontWeight: 600, color: "#374151", marginBottom: 8 }}>
+                  Team Colors
+                </p>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+                  {/* Offense color */}
+                  <div>
+                    <label
+                      htmlFor="edit-offense-color"
+                      style={{ display: "block", fontSize: 12, fontWeight: 500, color: "#6B7280", marginBottom: 6 }}
+                    >
+                      Offense
+                    </label>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <input
+                        id="edit-offense-color"
+                        type="color"
+                        value={editOffenseColor}
+                        onChange={(e) => setEditOffenseColor(e.target.value)}
+                        style={{
+                          width: 36,
+                          height: 36,
+                          padding: 2,
+                          border: "1.5px solid #D1D5DB",
+                          borderRadius: 6,
+                          cursor: "pointer",
+                          background: "none",
+                        }}
+                        aria-label="Offense team color"
+                      />
+                      <span
+                        style={{
+                          fontSize: 12,
+                          color: "#6B7280",
+                          fontFamily: "monospace",
+                          userSelect: "all",
+                        }}
+                      >
+                        {editOffenseColor.toUpperCase()}
+                      </span>
+                      {editOffenseColor !== DEFAULT_OFFENSE_COLOR && (
+                        <button
+                          type="button"
+                          onClick={() => setEditOffenseColor(DEFAULT_OFFENSE_COLOR)}
+                          title="Reset to default"
+                          style={{
+                            fontSize: 11,
+                            color: "#9CA3AF",
+                            background: "none",
+                            border: "none",
+                            cursor: "pointer",
+                            padding: 0,
+                            textDecoration: "underline",
+                          }}
+                        >
+                          Reset
+                        </button>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Defense color */}
+                  <div>
+                    <label
+                      htmlFor="edit-defense-color"
+                      style={{ display: "block", fontSize: 12, fontWeight: 500, color: "#6B7280", marginBottom: 6 }}
+                    >
+                      Defense
+                    </label>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <input
+                        id="edit-defense-color"
+                        type="color"
+                        value={editDefenseColor}
+                        onChange={(e) => setEditDefenseColor(e.target.value)}
+                        style={{
+                          width: 36,
+                          height: 36,
+                          padding: 2,
+                          border: "1.5px solid #D1D5DB",
+                          borderRadius: 6,
+                          cursor: "pointer",
+                          background: "none",
+                        }}
+                        aria-label="Defense team color"
+                      />
+                      <span
+                        style={{
+                          fontSize: 12,
+                          color: "#6B7280",
+                          fontFamily: "monospace",
+                          userSelect: "all",
+                        }}
+                      >
+                        {editDefenseColor.toUpperCase()}
+                      </span>
+                      {editDefenseColor !== DEFAULT_DEFENSE_COLOR && (
+                        <button
+                          type="button"
+                          onClick={() => setEditDefenseColor(DEFAULT_DEFENSE_COLOR)}
+                          title="Reset to default"
+                          style={{
+                            fontSize: 11,
+                            color: "#9CA3AF",
+                            background: "none",
+                            border: "none",
+                            cursor: "pointer",
+                            padding: 0,
+                            textDecoration: "underline",
+                          }}
+                        >
+                          Reset
+                        </button>
+                      )}
+                    </div>
+                  </div>
                 </div>
               </div>
 

--- a/src/components/court/Court.tsx
+++ b/src/components/court/Court.tsx
@@ -78,13 +78,18 @@ export interface CourtProps {
    */
   onReady?: (payload: CourtReadyPayload) => void;
   className?: string;
+  /**
+   * Optional color for the paint (free-throw lane) fill.
+   * Defaults to "#E07B39" (orange).
+   */
+  paintColor?: string;
 }
 
 // ---------------------------------------------------------------------------
 // Colours
 // ---------------------------------------------------------------------------
 const COLOR_COURT = "#F0C878"; // warm maple
-const COLOR_PAINT = "#E07B39"; // standard orange paint
+const DEFAULT_COLOR_PAINT = "#E07B39"; // standard orange paint
 const COLOR_LINE = "#FFFFFF";  // white lines
 const COLOR_LINE_WIDTH_PX = 2; // base line width — scaled by canvas resolution
 
@@ -100,7 +105,7 @@ const COLOR_LINE_WIDTH_PX = 2; // base line width — scaled by canvas resolutio
  * full court (the far end is drawn with an additional ctx.scale(1,-1) so it
  * appears mirrored / upside-down, which is the correct NBA full-court layout).
  */
-function drawHalfCourtInner(ctx: CanvasRenderingContext2D, W: number, H: number): void {
+function drawHalfCourtInner(ctx: CanvasRenderingContext2D, W: number, H: number, paintColor = DEFAULT_COLOR_PAINT): void {
   const cx = (nx: number) => nx * W;
   const cy = (ny: number) => ny * H;
   const rx = (nr: number) => nr * W;
@@ -117,7 +122,7 @@ function drawHalfCourtInner(ctx: CanvasRenderingContext2D, W: number, H: number)
   // ------------------------------------------------------------------
   // 2. Paint (free-throw lane)
   // ------------------------------------------------------------------
-  ctx.fillStyle = COLOR_PAINT;
+  ctx.fillStyle = paintColor;
   ctx.fillRect(cx(LANE_LEFT), cy(LANE_TOP), cx(LANE_RIGHT) - cx(LANE_LEFT), cy(1) - cy(LANE_TOP));
 
   // ------------------------------------------------------------------
@@ -268,6 +273,7 @@ export function drawCourt(
   cssWidth: number,
   cssHeight: number,
   variant: CourtVariant,
+  paintColor?: string,
 ): void {
   const ctx = canvas.getContext("2d");
   if (!ctx) return;
@@ -280,14 +286,14 @@ export function drawCourt(
     // Near basket end (bottom half) — normal orientation
     ctx.save();
     ctx.translate(0, halfH);
-    drawHalfCourtInner(ctx, cssWidth, halfH);
+    drawHalfCourtInner(ctx, cssWidth, halfH, paintColor);
     ctx.restore();
 
     // Far basket end (top half) — mirrored vertically around the centre line
     ctx.save();
     ctx.translate(0, halfH);
     ctx.scale(1, -1);
-    drawHalfCourtInner(ctx, cssWidth, halfH);
+    drawHalfCourtInner(ctx, cssWidth, halfH, paintColor);
     ctx.restore();
 
     // Draw the centre line and full centre circle explicitly to avoid any
@@ -311,7 +317,7 @@ export function drawCourt(
     ctx.restore();
     ctx.stroke();
   } else {
-    drawHalfCourtInner(ctx, cssWidth, cssHeight);
+    drawHalfCourtInner(ctx, cssWidth, cssHeight, paintColor);
   }
 }
 
@@ -319,7 +325,7 @@ export function drawCourt(
 // Component
 // ---------------------------------------------------------------------------
 
-export default function Court({ variant = "half", onReady, className }: CourtProps) {
+export default function Court({ variant = "half", onReady, className, paintColor }: CourtProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -346,7 +352,7 @@ export default function Court({ variant = "half", onReady, className }: CourtPro
       ctx.scale(dpr, dpr);
     }
 
-    drawCourt(canvas, cssWidth, cssHeight, variant);
+    drawCourt(canvas, cssWidth, cssHeight, variant, paintColor);
 
     // Notify parent with coordinate conversion helper and play-area metadata
     if (onReady) {
@@ -367,7 +373,7 @@ export default function Court({ variant = "half", onReady, className }: CourtPro
         playAreaOffsetY,
       });
     }
-  }, [variant, onReady]);
+  }, [variant, onReady, paintColor]);
 
   useEffect(() => {
     draw();

--- a/src/components/editor/SceneStrip.tsx
+++ b/src/components/editor/SceneStrip.tsx
@@ -24,8 +24,21 @@ import InfoTooltip from "./InfoTooltip";
 // Mini court thumbnail
 // ---------------------------------------------------------------------------
 
+const DEFAULT_OFFENSE_COLOR = "#3B82F6"; // blue used in strip thumbnails
+const DEFAULT_DEFENSE_COLOR = "#1E3A5F";
+
 /** Renders a tiny SVG court with coloured dots for visible players. */
-function SceneThumbnail({ scene, compact = false }: { scene: Scene; compact?: boolean }) {
+function SceneThumbnail({
+  scene,
+  compact = false,
+  offenseColor = DEFAULT_OFFENSE_COLOR,
+  defenseColor = DEFAULT_DEFENSE_COLOR,
+}: {
+  scene: Scene;
+  compact?: boolean;
+  offenseColor?: string;
+  defenseColor?: string;
+}) {
   const W = compact ? 80 : 120;
   const H = Math.round(W * (47 / 50)); // half-court aspect ratio: 50ft wide × 47ft deep
 
@@ -138,7 +151,7 @@ function SceneThumbnail({ scene, compact = false }: { scene: Scene; compact?: bo
       {/* Basket */}
       <circle cx={px(0.5)} cy={py(0.888)} r={compact ? 2 : 3} fill="none" stroke="#fff" strokeWidth={0.8} />
 
-      {/* Offensive players — blue fill */}
+      {/* Offensive players */}
       {scene.players.offense
         .filter((p) => p.visible)
         .map((p) => (
@@ -147,13 +160,13 @@ function SceneThumbnail({ scene, compact = false }: { scene: Scene; compact?: bo
             cx={px(p.x)}
             cy={py(p.y)}
             r={4}
-            fill="#3B82F6"
+            fill={offenseColor}
             stroke="#fff"
             strokeWidth={0.8}
           />
         ))}
 
-      {/* Defensive players — dark fill */}
+      {/* Defensive players */}
       {scene.players.defense
         .filter((p) => p.visible)
         .map((p) => (
@@ -162,7 +175,7 @@ function SceneThumbnail({ scene, compact = false }: { scene: Scene; compact?: bo
             cx={px(p.x)}
             cy={py(p.y)}
             r={4}
-            fill="#1E3A5F"
+            fill={defenseColor}
             stroke="#fff"
             strokeWidth={0.8}
           />
@@ -296,9 +309,11 @@ interface SceneCardProps {
   isActive: boolean;
   compact: boolean;
   onClick: () => void;
+  offenseColor?: string;
+  defenseColor?: string;
 }
 
-function SceneCard({ scene, index, totalScenes, isActive, compact, onClick }: SceneCardProps) {
+function SceneCard({ scene, index, totalScenes, isActive, compact, onClick, offenseColor, defenseColor }: SceneCardProps) {
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
 
   const handleContextMenu = (e: React.MouseEvent) => {
@@ -335,7 +350,7 @@ function SceneCard({ scene, index, totalScenes, isActive, compact, onClick }: Sc
           if (!isActive) (e.currentTarget as HTMLButtonElement).style.background = "#F9FAFB";
         }}
       >
-        <SceneThumbnail scene={scene} compact={compact} />
+        <SceneThumbnail scene={scene} compact={compact} offenseColor={offenseColor} defenseColor={defenseColor} />
         <span
           style={{
             fontSize: 11,
@@ -392,6 +407,7 @@ export default function SceneStrip() {
   const setCurrentSceneIndex = useStore((s) => s.setCurrentSceneIndex);
   const addScene = useStore((s) => s.addScene);
   const scene = useStore(selectEditorScene);
+  const playColors = useStore((s) => s.currentPlay?.colors);
 
   /**
    * Issue #81 — at tablet widths use compact (smaller) scene thumbnails
@@ -443,6 +459,8 @@ export default function SceneStrip() {
           isActive={s.id === activeId}
           compact={isTablet}
           onClick={() => { setSelectedSceneId(s.id); setCurrentSceneIndex(i); }}
+          offenseColor={playColors?.offense}
+          defenseColor={playColors?.defense}
         />
       ))}
 

--- a/src/components/playbook/PlayCard.tsx
+++ b/src/components/playbook/PlayCard.tsx
@@ -26,7 +26,18 @@ import { addPlayToTeam, deletePlay, savePlay } from "@/lib/db";
 // Inline mini court thumbnail (same logic as SceneStrip's SceneThumbnail)
 // ---------------------------------------------------------------------------
 
-function PlayThumbnail({ scene }: { scene: Scene }) {
+const DEFAULT_OFFENSE_COLOR = "#E07B39";
+const DEFAULT_DEFENSE_COLOR = "#1E3A5F";
+
+function PlayThumbnail({
+  scene,
+  offenseColor = DEFAULT_OFFENSE_COLOR,
+  defenseColor = DEFAULT_DEFENSE_COLOR,
+}: {
+  scene: Scene;
+  offenseColor?: string;
+  defenseColor?: string;
+}) {
   const W = 200;
   const H = Math.round(W / (50 / 47)); // ~188 px
 
@@ -50,7 +61,7 @@ function PlayThumbnail({ scene }: { scene: Scene }) {
         y={py(0.596)}
         width={px(0.32)}
         height={py(0.404)}
-        fill="#E07B39"
+        fill={offenseColor}
       />
 
       {/* Court outline */}
@@ -134,7 +145,7 @@ function PlayThumbnail({ scene }: { scene: Scene }) {
             cx={px(p.x)}
             cy={py(p.y)}
             r={4}
-            fill="#E07B39"
+            fill={offenseColor}
             stroke="#fff"
             strokeWidth={1}
           />
@@ -149,7 +160,7 @@ function PlayThumbnail({ scene }: { scene: Scene }) {
             cx={px(p.x)}
             cy={py(p.y)}
             r={4}
-            fill="#1E3A5F"
+            fill={defenseColor}
             stroke="#fff"
             strokeWidth={1}
           />
@@ -269,7 +280,11 @@ export default function PlayCard({ play, teamId, role }: PlayCardProps) {
         }}
       >
         {firstScene ? (
-          <PlayThumbnail scene={firstScene} />
+          <PlayThumbnail
+            scene={firstScene}
+            offenseColor={play.colors?.offense}
+            defenseColor={play.colors?.defense}
+          />
         ) : (
           <div
             style={{

--- a/src/components/players/CourtWithPlayers.tsx
+++ b/src/components/players/CourtWithPlayers.tsx
@@ -152,6 +152,7 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
   const updateBallState    = useStore((s) => s.updateBallState);
   const displayMode        = useStore((s) => s.playerDisplayMode);
   const playerNames        = useStore((s) => s.playerNames);
+  const playColors         = useStore((s) => s.currentPlay?.colors);
 
   // Court layout reported by the Court canvas
   const [courtSize, setCourtSize] = useState<{ width: number; height: number } | null>(null);
@@ -506,7 +507,7 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
   return (
     <div className={`relative ${className ?? "w-full"}`}>
       {/* Court canvas */}
-      <Court variant={variant} onReady={handleCourtReady} className="w-full" />
+      <Court variant={variant} onReady={handleCourtReady} className="w-full" paintColor={playColors?.offense} />
 
       {/* SVG player + ball overlay — same dimensions as the canvas */}
       {courtSize && (
@@ -547,6 +548,7 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
                   displayMode={displayMode}
                   playerName={playerNames[`defense-${p.position}`]}
                   radius={tokenRadius}
+                  defenseColor={playColors?.defense}
                 />
               ))}
 
@@ -572,6 +574,7 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
                   displayMode={displayMode}
                   playerName={playerNames[`offense-${p.position}`]}
                   radius={tokenRadius}
+                  offenseColor={playColors?.offense}
                 />
               ))}
 

--- a/src/components/players/PlayerToken.tsx
+++ b/src/components/players/PlayerToken.tsx
@@ -45,7 +45,7 @@ const COLOR_OFFENSE_STROKE = "#FFFFFF";
 const COLOR_DEFENSE_FILL = "#FFFFFF";
 const COLOR_DEFENSE_STROKE = "#1E3A5F"; // dark navy
 const COLOR_TEXT_OFFENSE = "#FFFFFF";
-const COLOR_TEXT_DEFENSE = "#1E3A5F";
+// Defense text color uses the resolved defense color (same as border/X stroke)
 
 // ---------------------------------------------------------------------------
 // Types
@@ -80,6 +80,16 @@ export interface PlayerTokenProps {
   playerName?: string;
   /** Token radius in CSS pixels. Defaults to PLAYER_RADIUS (18). */
   radius?: number;
+  /**
+   * Custom fill color for the offense token (overrides COLOR_OFFENSE_FILL).
+   * Only used when side === "offense".
+   */
+  offenseColor?: string;
+  /**
+   * Custom accent color for the defense token (overrides COLOR_DEFENSE_STROKE).
+   * Only used when side === "defense".
+   */
+  defenseColor?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -97,6 +107,8 @@ export default function PlayerToken({
   displayMode = "numbers",
   playerName,
   radius = PLAYER_RADIUS,
+  offenseColor,
+  defenseColor,
 }: PlayerTokenProps) {
   const isDragging = useRef(false);
   const dragStart = useRef<{ mouseX: number; mouseY: number; playerCx: number; playerCy: number }>({
@@ -200,9 +212,11 @@ export default function PlayerToken({
   );
 
   const isOffense = side === "offense";
-  const fillColor = isOffense ? COLOR_OFFENSE_FILL : COLOR_DEFENSE_FILL;
-  const strokeColor = isOffense ? COLOR_OFFENSE_STROKE : COLOR_DEFENSE_STROKE;
-  const textColor = isOffense ? COLOR_TEXT_OFFENSE : COLOR_TEXT_DEFENSE;
+  const resolvedOffenseColor = offenseColor ?? COLOR_OFFENSE_FILL;
+  const resolvedDefenseColor = defenseColor ?? COLOR_DEFENSE_STROKE;
+  const fillColor = isOffense ? resolvedOffenseColor : COLOR_DEFENSE_FILL;
+  const strokeColor = isOffense ? COLOR_OFFENSE_STROKE : resolvedDefenseColor;
+  const textColor = isOffense ? COLOR_TEXT_OFFENSE : resolvedDefenseColor;
   const strokeWidth = isOffense ? 2 : 2.5;
 
   // Build label based on display mode
@@ -259,7 +273,7 @@ export default function PlayerToken({
             y1={-xSize}
             x2={xSize}
             y2={xSize}
-            stroke={COLOR_DEFENSE_STROKE}
+            stroke={resolvedDefenseColor}
             strokeWidth={scaledStrokeWidth}
             strokeLinecap="round"
           />
@@ -268,7 +282,7 @@ export default function PlayerToken({
             y1={-xSize}
             x2={-xSize}
             y2={xSize}
-            stroke={COLOR_DEFENSE_STROKE}
+            stroke={resolvedDefenseColor}
             strokeWidth={scaledStrokeWidth}
             strokeLinecap="round"
           />

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -6,6 +6,7 @@ import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import type {
   Play,
+  PlayColors,
   Scene,
   TimingGroup,
   Annotation,
@@ -63,6 +64,7 @@ export interface AppStore {
   updatePlayMeta: (
     patch: Partial<Pick<Play, "title" | "description" | "category" | "tags" | "courtType">>,
   ) => void;
+  updatePlayColors: (colors: PlayColors) => void;
 
   // Undo / Redo (issue #83)
   undo: () => void;
@@ -327,6 +329,12 @@ export const useStore = create<AppStore>()(
       set((state) => {
         if (!state.currentPlay) return state;
         return { currentPlay: { ...state.currentPlay, ...patch, updatedAt: new Date() } };
+      }),
+
+    updatePlayColors: (colors) =>
+      set((state) => {
+        if (!state.currentPlay) return state;
+        return { currentPlay: { ...state.currentPlay, colors, updatedAt: new Date() } };
       }),
 
     // -----------------------------------------------------------------------

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -87,6 +87,13 @@ export interface Team {
   inviteCode: string;
 }
 
+export interface PlayColors {
+  /** Fill color for offensive player tokens (defaults to "#E07B39"). */
+  offense: string;
+  /** Stroke/X color for defensive player tokens (defaults to "#1E3A5F"). */
+  defense: string;
+}
+
 export interface Play {
   id: string;
   teamId: string;
@@ -99,6 +106,8 @@ export interface Play {
   createdAt: Date;
   updatedAt: Date;
   scenes: Scene[];
+  /** Optional custom colors for offensive and defensive player tokens. */
+  colors?: PlayColors;
 }
 
 export interface User {


### PR DESCRIPTION
## Summary

- Adds a `PlayColors` interface (`{ offense: string; defense: string }`) and an optional `colors` field on the `Play` type, persisted in Firestore with the rest of the play document
- Adds `updatePlayColors` action to the Zustand store
- The **Edit Play** modal in the editor gains color pickers (native `<input type="color">`) for offense and defense with a hex display and per-color Reset link
- `PlayerToken` accepts `offenseColor` and `defenseColor` props that override the hardcoded constants for the token fill, stroke, X lines, and label color
- `Court` / `drawCourt` accept an optional `paintColor` prop to tint the free-throw lane fill to match the offense color
- `CourtWithPlayers` reads `currentPlay.colors` from the store and passes the colors down to `Court` and both sets of `PlayerToken`s
- `SceneStrip` thumbnails and `PlayCard` thumbnails both respect the play's custom colors for player dots and lane fill

## Test plan

- [ ] Open a play in the editor; click the pencil (Edit Play)
- [ ] Verify the "Team Colors" section appears with two color pickers (Offense, Defense)
- [ ] Change offense color — player tokens on the court update immediately after saving
- [ ] Change defense color — defense X tokens and their labels update after saving
- [ ] Court paint (lane fill) matches the offense color
- [ ] Scene strip thumbnails reflect the custom colors
- [ ] Return to the playbook grid — PlayCard thumbnail reflects the custom colors
- [ ] Reload the page — colors are persisted via Firestore (saved with the play document)
- [ ] Reset links restore the original orange/navy defaults
- [ ] A play without saved colors renders with the original defaults

## Notes

- Colors are stored per-play, so each play can have its own colors
- Existing plays without a `colors` field continue to show the original orange/navy defaults (backward compatible)
- Please squash-merge this PR

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)