### PR TITLE
Fix #128: Guard assignment annotation (defender follow + defensive switch)

### DIFF
--- a/src/components/annotations/AnnotationLayer.tsx
+++ b/src/components/annotations/AnnotationLayer.tsx
@@ -258,6 +258,30 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
     );
   }
 
+  if (type === "guard") {
+    // Guard assignment: dashed line from defender to offensive player.
+    // Rendered in amber/orange to be visually distinct from cut (red dashed)
+    // and from movement (solid navy). No arrowhead — it is a static assignment link.
+    return (
+      <g onClick={handleClick} style={hitStyle}>
+        {selectRing}
+        <line
+          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+          stroke="transparent" strokeWidth={14}
+        />
+        <line
+          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+          stroke="#D97706"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeDasharray="4 4"
+          opacity={0.85}
+        />
+        {stepBadge}
+      </g>
+    );
+  }
+
   return null;
 }
 
@@ -338,6 +362,14 @@ function PreviewAnnotation({
       <g pointerEvents="none" opacity={0.7}>
         <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke="#DC2626" strokeWidth={2.5} strokeLinecap="round" strokeDasharray="7 5" />
         {headPoints && <polygon points={headPoints} fill="#DC2626" opacity={0.8} />}
+      </g>
+    );
+  }
+
+  if (tool === "guard") {
+    return (
+      <g pointerEvents="none" opacity={0.7}>
+        <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke="#D97706" strokeWidth={2} strokeLinecap="round" strokeDasharray="4 4" />
       </g>
     );
   }
@@ -467,27 +499,39 @@ export default function AnnotationLayer({
   // Keyboard Delete/Backspace for annotation removal is handled centrally by
   // EditorKeyboardManager (useKeyboardShortcuts, issue #82). No listener here.
 
+  // For the guard tool we restrict snap-to-player by side:
+  //   - mousedown: snap to defense only (the defender is the "from")
+  //   - mousemove / mouseup: snap to offense only (the offensive player being guarded)
+  const defenseOnly = players.filter((p) => p.side === "defense");
+  const offenseOnly = players.filter((p) => p.side === "offense");
+
   // Mouse down — start drawing
   const handleMouseDown = useCallback(
     (e: React.MouseEvent<SVGSVGElement>) => {
       if (!isDrawingTool || selectedTool === "eraser") return;
       e.preventDefault();
       const pt = getSVGCoords(e);
-      const nearest = findNearestPlayer(pt.x, pt.y, players);
+      const snapPool = selectedTool === "guard" ? defenseOnly : players;
+      const nearest = findNearestPlayer(pt.x, pt.y, snapPool);
       const from: Point = nearest ? { x: nearest.px, y: nearest.py } : pt;
       const stroke = { from, to: from };
       setDrawing(stroke);
       drawingRef.current = stroke;
       setSnapTarget(null);
     },
-    [isDrawingTool, selectedTool, getSVGCoords, players],
+    [isDrawingTool, selectedTool, getSVGCoords, players, defenseOnly],
   );
 
   // Mouse move — update preview
   const handleMouseMove = useCallback(
     (e: React.MouseEvent<SVGSVGElement>) => {
       const pt = getSVGCoords(e);
-      const nearest = findNearestPlayer(pt.x, pt.y, players);
+      // While dragging a guard annotation, snap the endpoint to offense only.
+      const snapPool =
+        selectedTool === "guard" && drawingRef.current
+          ? offenseOnly
+          : players;
+      const nearest = findNearestPlayer(pt.x, pt.y, snapPool);
       setSnapTarget(nearest);
 
       if (!drawingRef.current) return;
@@ -496,7 +540,7 @@ export default function AnnotationLayer({
       drawingRef.current = next;
       setDrawing(next);
     },
-    [getSVGCoords, players],
+    [getSVGCoords, players, offenseOnly, selectedTool],
   );
 
   // Mouse up — commit annotation
@@ -509,14 +553,18 @@ export default function AnnotationLayer({
       }
       const { from } = drawingRef.current;
       const pt = getSVGCoords(e);
-      const nearest = findNearestPlayer(pt.x, pt.y, players);
+      // Guard: endpoint snaps to offense only
+      const toSnapPool = selectedTool === "guard" ? offenseOnly : players;
+      const nearest = findNearestPlayer(pt.x, pt.y, toSnapPool);
       const to: Point = nearest ? { x: nearest.px, y: nearest.py } : pt;
 
       // Ignore tiny strokes (accidental clicks)
       const dx = to.x - from.x;
       const dy = to.y - from.y;
       if (Math.sqrt(dx * dx + dy * dy) > 8) {
-        const fromNearest = findNearestPlayer(from.x, from.y, players);
+        // Guard: from-player must come from defense pool
+        const fromSnapPool = selectedTool === "guard" ? defenseOnly : players;
+        const fromNearest = findNearestPlayer(from.x, from.y, fromSnapPool);
         const annotation: Annotation = {
           id: crypto.randomUUID(),
           type: selectedTool as Annotation["type"],
@@ -546,6 +594,8 @@ export default function AnnotationLayer({
       selectedTimingStep,
       getSVGCoords,
       players,
+      offenseOnly,
+      defenseOnly,
       addAnnotation,
       setSelectedAnnotationId,
       width,

--- a/src/components/editor/DrawingToolsPanel.tsx
+++ b/src/components/editor/DrawingToolsPanel.tsx
@@ -13,6 +13,7 @@
  *   Pass           (keyboard: P) — line with triangle tip
  *   Screen         (keyboard: S) — perpendicular line
  *   Cut            (keyboard: C) — dashed arrow line
+ *   Guard          (keyboard: G) — defender→offensive player assignment (amber dashed)
  *   Eraser         (keyboard: E) — remove annotations
  *
  * Note: keyboard shortcut registration has been centralised in
@@ -133,6 +134,30 @@ function CutIcon({ active }: { active: boolean }) {
   );
 }
 
+/** Guard tool icon (dashed line with a small shield / target at the end) */
+function GuardIcon({ active }: { active: boolean }) {
+  const c = active ? ACTIVE_COLOR : IDLE_COLOR;
+  return (
+    <svg viewBox="0 0 28 28" width={22} height={22} aria-hidden="true">
+      {/* Dashed line from defender to offensive player */}
+      <line
+        x1="6"
+        y1="22"
+        x2="20"
+        y2="8"
+        stroke={c}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeDasharray="3 3"
+      />
+      {/* Defender circle at start */}
+      <circle cx={6} cy={22} r={4} fill="none" stroke={c} strokeWidth={2} />
+      {/* Offensive player circle at end */}
+      <circle cx={20} cy={8} r={4} fill={c} />
+    </svg>
+  );
+}
+
 /** Eraser tool icon */
 function EraserIcon({ active }: { active: boolean }) {
   const c = active ? ACTIVE_COLOR : IDLE_COLOR;
@@ -162,6 +187,7 @@ const TOOLS: ToolDef[] = [
   { id: "pass",     label: "Pass",     shortcut: "P", Icon: PassIcon     },
   { id: "screen",   label: "Screen",   shortcut: "S", Icon: ScreenIcon   },
   { id: "cut",      label: "Cut",      shortcut: "C", Icon: CutIcon      },
+  { id: "guard",    label: "Guard",    shortcut: "G", Icon: GuardIcon    },
   { id: "eraser",   label: "Eraser",   shortcut: "E", Icon: EraserIcon   },
 ];
 
@@ -173,6 +199,7 @@ export const TOOL_CURSOR: Record<DrawingTool, string> = {
   pass:     "crosshair",
   screen:   "crosshair",
   cut:      "crosshair",
+  guard:    "crosshair",
   eraser:   "cell",
 };
 

--- a/src/components/editor/ShortcutsOverlay.tsx
+++ b/src/components/editor/ShortcutsOverlay.tsx
@@ -31,6 +31,7 @@ const SECTIONS: ShortcutSection[] = [
       { keys: ["P"], description: "Pass arrow" },
       { keys: ["S"], description: "Screen / pick" },
       { keys: ["C"], description: "Cut (dashed arrow)" },
+      { keys: ["G"], description: "Guard assignment (defender → offensive player)" },
       { keys: ["E"], description: "Eraser" },
       { keys: ["Esc"], description: "Back to Select" },
     ],

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -7,7 +7,7 @@
  *
  * Shortcuts registered here:
  *   Tool switching   : V (select), M (move), D (dribble), P (pass),
- *                      S (screen), C (cut), E (eraser)
+ *                      S (screen), C (cut), G (guard), E (eraser)
  *   Playback         : Space (play/pause), Left/Right (step scenes),
  *                      L (loop toggle)
  *   Scene navigation : Ctrl+Right / Ctrl+Left (next/prev scene)
@@ -46,6 +46,7 @@ const TOOL_KEY_MAP: Record<string, DrawingTool> = {
   p: "pass",
   s: "screen",
   c: "cut",
+  g: "guard",
   e: "eraser",
 };
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -28,6 +28,7 @@ export type DrawingTool =
   | "pass"
   | "screen"
   | "cut"
+  | "guard"
   | "eraser";
 
 export type PlaybackSpeed = 0.5 | 1 | 1.5 | 2;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,7 +14,7 @@ export type Category =
   | "oob"
   | "special";
 
-export type AnnotationType = "movement" | "dribble" | "pass" | "screen" | "cut";
+export type AnnotationType = "movement" | "dribble" | "pass" | "screen" | "cut" | "guard";
 
 export interface Point {
   x: number;


### PR DESCRIPTION
## Summary

Resolves #128 — adds a **Guard** annotation tool that lets coaches assign a defender to guard a specific offensive player.

- New `"guard"` annotation type stored in `scene.timingGroups[].annotations` alongside existing types
- New **Guard** tool in the drawing tools panel (amber dashed line icon, keyboard shortcut **G**)
- Drawing interaction: click a defensive player (from), then drag to an offensive player (to) — endpoints snap to the correct side automatically (defense-only snap at start, offense-only snap at end)
- Rendered as an **amber dashed line** (`#D97706`, `strokeDasharray="4 4"`, no arrowhead) — visually distinct from the red cut dashes and solid movement arrows
- **Defensive switch** is handled naturally: update guard assignments in the next scene and the dashed lines animate to their new targets during scene transitions — no extra annotation type needed
- Keyboard shortcut **G** wired into `useKeyboardShortcuts`, documented in the shortcuts overlay

## Files changed

- `src/lib/types.ts` — added `"guard"` to `AnnotationType`
- `src/lib/store.ts` — added `"guard"` to `DrawingTool`
- `src/components/editor/DrawingToolsPanel.tsx` — `GuardIcon` SVG, tool entry, `TOOL_CURSOR` entry
- `src/components/annotations/AnnotationLayer.tsx` — rendered + preview guard annotation; side-filtered snap logic
- `src/hooks/useKeyboardShortcuts.ts` — `G` key mapped to guard tool
- `src/components/editor/ShortcutsOverlay.tsx` — shortcut docs updated

## Test plan

- [ ] Open a play in the editor, press **G** — Guard tool becomes active
- [ ] Click a defender (X token) and drag to an offensive player (O token) — amber dashed line appears
- [ ] Snap indicator appears only over defense players at stroke start; only over offense players while dragging
- [ ] Annotation is erasable with the Eraser tool (E)
- [ ] Duplicate scene — guard annotation does not project positions (correct: it's an assignment not a movement)
- [ ] Draw guard assignments in scene 1, change assignments in scene 2 — dashed lines "switch" during playback
- [ ] TypeScript check and build pass with no errors

> Note: please squash-merge this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)