### PR TITLE
Fix presentation mode arrows hidden on entry

### DIFF
--- a/src/components/editor/PresentationOverlay.tsx
+++ b/src/components/editor/PresentationOverlay.tsx
@@ -106,12 +106,14 @@ export default function PresentationOverlay() {
   }, []);
 
   useEffect(() => {
-    // Show controls on mount and start the hide timer
-    showControls();
+    // Show controls on mount WITHOUT starting the hide timer — controls stay
+    // visible until the first mouse/pointer interaction, which then starts
+    // the 3-second auto-hide countdown via showControls().
+    setControlsVisible(true);
     return () => {
       if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
     };
-  }, [showControls]);
+  }, []);
 
   // ---------------------------------------------------------------------------
   // Keyboard shortcuts: Space, Left/Right, Esc


### PR DESCRIPTION
## Summary
- On mount, `showControls()` was immediately starting a 3-second hide timer
- Controls (including nav arrows) would vanish after 3s even without any user interaction
- Fix: call `setControlsVisible(true)` on mount without scheduling the hide timer
- Auto-hide timer now only starts after the first mouse/pointer interaction (standard video-player behaviour)

## Test plan
- [ ] Enter presentation mode → arrows visible immediately
- [ ] Wait 5+ seconds without moving mouse → arrows still visible
- [ ] Move mouse → arrows visible, then hide after 3s of inactivity
- [ ] Move mouse again → arrows reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)