### PR TITLE
feat: three court improvements — line anchoring, flip, OOB space

### DIFF
--- a/src/app/play/[id]/EditorCourtArea.tsx
+++ b/src/app/play/[id]/EditorCourtArea.tsx
@@ -23,6 +23,7 @@ import { useStore, createDefaultPlay, selectEditorScene } from "@/lib/store";
 import CourtWithPlayers from "@/components/players/CourtWithPlayers";
 import type { CourtVariant } from "@/components/court/Court";
 import { COURT_ASPECT_RATIO } from "@/components/court/courtDimensions";
+import { OOB_SIDE_FRAC, OOB_BOTTOM_FRAC } from "@/components/court/Court";
 import { loadPlay } from "@/lib/db";
 import { useTeam } from "@/contexts/TeamContext";
 import { useAuth } from "@/contexts/AuthContext";
@@ -35,6 +36,11 @@ export default function EditorCourtArea({ playId }: EditorCourtAreaProps) {
   const scene = useStore(selectEditorScene);
   const selectedSceneId = useStore((s) => s.selectedSceneId);
   const courtType = useStore((s) => s.currentPlay?.courtType ?? "half");
+  const currentPlay = useStore((s) => s.currentPlay);
+  // Effective flip: scene override if set, otherwise play-level value
+  const sceneFlip = scene?.flipped;
+  const playFlipped = currentPlay?.flipped ?? false;
+  const effectiveFlipped = sceneFlip != null ? sceneFlip : playFlipped;
   const { role } = useTeam();
   const isReadOnly = role === "viewer";
   // Wait for Firebase Auth to restore the previous session before hitting
@@ -57,8 +63,11 @@ export default function EditorCourtArea({ playId }: EditorCourtAreaProps) {
       if (!el) return;
       // Full court canvas is 2× taller than half court, so cap width at half
       // the available height × aspect ratio to prevent vertical overflow.
+      // OOB margins make the canvas slightly wider relative to the inner court,
+      // so oobFactor adjusts for that.
       const heightFactor = courtType === "full" ? 0.5 : 1;
-      setMaxCourtWidth(Math.round(el.clientHeight * heightFactor * COURT_ASPECT_RATIO));
+      const oobFactor = (1 + 2 * OOB_SIDE_FRAC) / (1 + OOB_BOTTOM_FRAC);
+      setMaxCourtWidth(Math.round(el.clientHeight * heightFactor * COURT_ASPECT_RATIO * oobFactor));
     });
     obs.observe(el);
     return () => obs.disconnect();
@@ -178,6 +187,7 @@ export default function EditorCourtArea({ playId }: EditorCourtAreaProps) {
           variant={courtType as CourtVariant}
           className="w-full max-w-full md:max-w-xl lg:max-w-3xl"
           readOnly={isReadOnly}
+          flipped={effectiveFlipped}
         />
       </div>
     </div>

--- a/src/app/play/[id]/EditorHeader.tsx
+++ b/src/app/play/[id]/EditorHeader.tsx
@@ -42,6 +42,7 @@ export default function EditorHeader({ playId, children }: EditorHeaderProps) {
   const updatePlayColors = useStore((s) => s.updatePlayColors);
   const isPresentationMode = useStore((s) => s.isPresentationMode);
   const enterPresentationMode = useStore((s) => s.enterPresentationMode);
+  const setPlayFlipped = useStore((s) => s.setPlayFlipped);
 
   const title = currentPlay?.title ?? null;
 
@@ -281,6 +282,25 @@ export default function EditorHeader({ playId, children }: EditorHeaderProps) {
             )}
             {shareMsg ?? (isSharing ? "Sharing…" : "Share")}
           </button>
+
+          {/* Flip court orientation button */}
+          {currentPlay && (
+            <button
+              onClick={() => setPlayFlipped(!(currentPlay.flipped ?? false))}
+              aria-label="Flip court orientation"
+              title="Flip court (basket north/south)"
+              aria-pressed={currentPlay.flipped ?? false}
+              className={`flex items-center justify-center w-7 h-7 rounded-md transition-colors ${
+                currentPlay.flipped
+                  ? "bg-indigo-100 text-indigo-700 hover:bg-indigo-200"
+                  : "text-gray-500 hover:bg-gray-100 hover:text-gray-900"
+              }`}
+            >
+              <svg width={16} height={16} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <path d="M8 2v12M5 5L2 8l3 3M11 5l3 3-3 3" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </button>
+          )}
 
           {/* Present button */}
           <button

--- a/src/components/annotations/AnnotationLayer.tsx
+++ b/src/components/annotations/AnnotationLayer.tsx
@@ -77,16 +77,28 @@ interface RenderedAnnotationProps {
   step?: number;
   /** Whether to show the step badge. */
   showStepBadge?: boolean;
-  /** Court canvas pixel dimensions — used to convert stored normalized coords to pixels. */
+  /** Inner play-area pixel dimensions — used to convert stored normalized coords to pixels. */
   width: number;
   height: number;
+  /** X offset from SVG left edge to play area (OOB side margin). Default 0. */
+  offsetX?: number;
+  /** Y offset from SVG top to play area. Default 0. */
+  offsetY?: number;
+  /** Whether the court is flipped (basket at top). */
+  flipped?: boolean;
 }
 
-function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, width, height }: RenderedAnnotationProps) {
+function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, width, height, offsetX = 0, offsetY = 0, flipped = false }: RenderedAnnotationProps) {
   const { type } = ann;
   // Annotations are stored in normalised [0-1] coords. Convert to CSS pixels for rendering.
-  const from = { x: ann.from.x * width, y: ann.from.y * height };
-  const to   = { x: ann.to.x   * width, y: ann.to.y   * height };
+  // width/height here are the play area (inner court) dimensions; offsetX/offsetY position
+  // the play area within the SVG canvas.
+  const normToSvg = (nx: number, ny: number) => ({
+    x: nx * width + offsetX,
+    y: flipped ? (1 - ny) * height + offsetY : ny * height + offsetY,
+  });
+  const from = normToSvg(ann.from.x, ann.from.y);
+  const to   = normToSvg(ann.to.x,   ann.to.y);
   const hitStyle: React.CSSProperties = { cursor: "pointer", pointerEvents: "stroke" };
 
   // Step badge — small circle at the midpoint of the annotation
@@ -412,14 +424,24 @@ function findNearestPlayer(
 // ---------------------------------------------------------------------------
 
 export interface AnnotationLayerProps {
-  /** CSS pixel width of the court canvas. */
+  /** Total SVG/canvas CSS pixel width (including OOB margins). */
   width: number;
-  /** CSS pixel height of the court canvas. */
+  /** Total SVG/canvas CSS pixel height (including OOB margins). */
   height: number;
+  /** Inner play-area width in CSS pixels (excluding OOB side margins). Defaults to width. */
+  playAreaWidth?: number;
+  /** Inner play-area height in CSS pixels (excluding OOB bottom margin). Defaults to height. */
+  playAreaHeight?: number;
+  /** X offset from SVG left edge to the play area (OOB side margin). Default 0. */
+  offsetX?: number;
+  /** Y offset from SVG top to the play area (for full court). Default 0. */
+  offsetY?: number;
   /** The scene ID currently being edited. */
   sceneId: string | null;
   /** Player positions for snap detection. */
   players: SnapPlayer[];
+  /** Whether the court is flipped (basket at top). */
+  flipped?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -429,9 +451,17 @@ export interface AnnotationLayerProps {
 export default function AnnotationLayer({
   width,
   height,
+  playAreaWidth,
+  playAreaHeight,
+  offsetX = 0,
+  offsetY = 0,
   sceneId,
   players,
+  flipped = false,
 }: AnnotationLayerProps) {
+  // Inner court dimensions for coordinate conversion
+  const paWidth  = playAreaWidth  ?? width;
+  const paHeight = playAreaHeight ?? height;
   const selectedTool = useStore((s) => s.selectedTool);
   const selectedTimingStep = useStore((s) => s.selectedTimingStep);
   const selectedAnnotationId = useStore((s) => s.selectedAnnotationId);
@@ -565,13 +595,17 @@ export default function AnnotationLayer({
         // Guard: from-player must come from defense pool
         const fromSnapPool = selectedTool === "guard" ? defenseOnly : players;
         const fromNearest = findNearestPlayer(from.x, from.y, fromSnapPool);
+        // Convert SVG pixel coords to normalised [0-1] court coords.
+        // Accounts for OOB side margins (offsetX) and flip.
+        const svgToNorm = (svgX: number, svgY: number) => ({
+          x: (svgX - offsetX) / paWidth,
+          y: flipped ? 1 - (svgY - offsetY) / paHeight : (svgY - offsetY) / paHeight,
+        });
         const annotation: Annotation = {
           id: crypto.randomUUID(),
           type: selectedTool as Annotation["type"],
-          // Store in normalised [0-1] coords so the store is resolution-independent
-          // and addScene can use annotation endpoints directly as player positions.
-          from: { x: from.x / width, y: from.y / height },
-          to:   { x: to.x   / width, y: to.y   / height },
+          from: svgToNorm(from.x, from.y),
+          to:   svgToNorm(to.x,   to.y),
           fromPlayer: fromNearest
             ? { side: fromNearest.side, position: fromNearest.position }
             : null,
@@ -598,8 +632,11 @@ export default function AnnotationLayer({
       defenseOnly,
       addAnnotation,
       setSelectedAnnotationId,
-      width,
-      height,
+      paWidth,
+      paHeight,
+      offsetX,
+      offsetY,
+      flipped,
     ],
   );
 
@@ -647,8 +684,11 @@ export default function AnnotationLayer({
           onSelect={handleAnnotationSelect}
           step={annotationStepMap.get(ann.id)}
           showStepBadge={showStepBadges}
-          width={width}
-          height={height}
+          width={paWidth}
+          height={paHeight}
+          offsetX={offsetX}
+          offsetY={offsetY}
+          flipped={flipped}
         />
       ))}
 

--- a/src/components/court/Court.tsx
+++ b/src/components/court/Court.tsx
@@ -49,21 +49,26 @@ export type CourtToCanvas = (normX: number, normY: number) => { x: number; y: nu
 export interface CourtReadyPayload {
   canvas: HTMLCanvasElement;
   courtToCanvas: CourtToCanvas;
-  /** Total canvas width in CSS pixels. */
+  /** Total canvas width in CSS pixels (inner court + OOB margins). */
   width: number;
-  /** Total canvas height in CSS pixels. */
+  /** Total canvas height in CSS pixels (inner court + OOB margin). */
   height: number;
   /**
-   * Height of the play area in CSS pixels.
-   * For half court this equals height; for full court it is height/2 (one end).
+   * Height of the play area (inner court) in CSS pixels.
+   * For half court this equals innerH; for full court it is innerH (one end).
    */
   playAreaHeight: number;
   /**
    * Y offset from the canvas top to the play area.
-   * For half court this is 0; for full court it is height/2 (players are in
-   * the near/bottom end of the full court canvas).
+   * For half court this is 0; for full court it is innerH + oobBot.
    */
   playAreaOffsetY: number;
+  /**
+   * X offset from the canvas left edge to the play area (OOB side margin).
+   */
+  playAreaOffsetX: number;
+  /** Inner court width in CSS pixels (canvas width minus 2× side OOB margin). */
+  playAreaWidth: number;
 }
 
 export interface CourtProps {
@@ -83,7 +88,22 @@ export interface CourtProps {
    * Defaults to "#E07B39" (orange).
    */
   paintColor?: string;
+  /**
+   * When true, flips the court so the basket is at the top (north).
+   * The flip is purely visual — normalised coords are unchanged.
+   */
+  flipped?: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// Out-of-bounds margin fractions (relative to inner court dimensions)
+// ---------------------------------------------------------------------------
+
+/** Side OOB margin on each side, as a fraction of inner court width. */
+export const OOB_SIDE_FRAC = 0.06;
+/** Bottom (baseline) OOB margin, as a fraction of inner court height. */
+export const OOB_BOTTOM_FRAC = 0.07;
+// No top margin — the half-court line is the court boundary.
 
 // ---------------------------------------------------------------------------
 // Colours
@@ -325,7 +345,7 @@ export function drawCourt(
 // Component
 // ---------------------------------------------------------------------------
 
-export default function Court({ variant = "half", onReady, className, paintColor }: CourtProps) {
+export default function Court({ variant = "half", onReady, className, paintColor, flipped = false }: CourtProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -336,32 +356,85 @@ export default function Court({ variant = "half", onReady, className, paintColor
 
     const dpr = window.devicePixelRatio ?? 1;
     const cssWidth = container.clientWidth;
-    const halfH = Math.round(cssWidth / COURT_ASPECT_RATIO);
-    const cssHeight = variant === "full" ? halfH * 2 : halfH;
+
+    // Compute OOB margins and inner court dimensions
+    const oobLeft = Math.round(cssWidth * OOB_SIDE_FRAC / (1 + 2 * OOB_SIDE_FRAC));
+    const innerW  = cssWidth - 2 * oobLeft;
+    const innerH  = Math.round(innerW / COURT_ASPECT_RATIO);
+    const oobBot  = Math.round(innerH * OOB_BOTTOM_FRAC);
+    const cssHeight = variant === "full" ? innerH * 2 + oobBot : innerH + oobBot;
 
     // Set CSS size
     canvas.style.width = `${cssWidth}px`;
     canvas.style.height = `${cssHeight}px`;
 
-    // Set backing store size (high-DPI)
+    // Set backing store size (high-DPI) — also clears the canvas and resets the context
     canvas.width = Math.round(cssWidth * dpr);
     canvas.height = Math.round(cssHeight * dpr);
 
     const ctx = canvas.getContext("2d");
-    if (ctx) {
-      ctx.scale(dpr, dpr);
+    if (!ctx) return;
+
+    ctx.scale(dpr, dpr);
+
+    // Apply vertical flip if requested (purely visual — courtToCanvas compensates)
+    if (flipped) {
+      ctx.translate(0, cssHeight);
+      ctx.scale(1, -1);
     }
 
-    drawCourt(canvas, cssWidth, cssHeight, variant, paintColor);
+    // Fill entire canvas with floor colour (covers OOB margins)
+    ctx.fillStyle = COLOR_COURT;
+    ctx.fillRect(0, 0, cssWidth, cssHeight);
+
+    if (variant === "full") {
+      // Near basket end (bottom half) — normal orientation
+      ctx.save();
+      ctx.translate(oobLeft, innerH + oobBot);
+      drawHalfCourtInner(ctx, innerW, innerH, paintColor);
+      ctx.restore();
+
+      // Far basket end (top half) — mirrored vertically
+      ctx.save();
+      ctx.translate(oobLeft, innerH + oobBot);
+      ctx.scale(1, -1);
+      drawHalfCourtInner(ctx, innerW, innerH, paintColor);
+      ctx.restore();
+
+      // Centre line
+      ctx.strokeStyle = COLOR_LINE;
+      ctx.lineWidth = COLOR_LINE_WIDTH_PX;
+      ctx.lineCap = "round";
+      ctx.beginPath();
+      ctx.moveTo(oobLeft, innerH + oobBot);
+      ctx.lineTo(oobLeft + innerW, innerH + oobBot);
+      ctx.stroke();
+
+      // Full centre circle
+      const scaleY = innerH / innerW;
+      ctx.save();
+      ctx.scale(1, scaleY);
+      ctx.beginPath();
+      ctx.arc(oobLeft + innerW * 0.5, (innerH + oobBot) / scaleY, innerW * CENTRE_CIRCLE_RADIUS, 0, Math.PI * 2);
+      ctx.restore();
+      ctx.stroke();
+    } else {
+      // Half court — translate right by OOB margin
+      ctx.save();
+      ctx.translate(oobLeft, 0);
+      drawHalfCourtInner(ctx, innerW, innerH, paintColor);
+      ctx.restore();
+    }
 
     // Notify parent with coordinate conversion helper and play-area metadata
     if (onReady) {
-      const playAreaHeight = variant === "full" ? halfH : cssHeight;
-      const playAreaOffsetY = variant === "full" ? halfH : 0;
+      const playAreaOffsetY = variant === "full" ? innerH + oobBot : 0;
 
       const courtToCanvas: CourtToCanvas = (normX, normY) => ({
-        x: normX * cssWidth,
-        y: normY * playAreaHeight + playAreaOffsetY,
+        x: normX * innerW + oobLeft,
+        y: flipped
+          ? (1 - normY) * innerH + playAreaOffsetY
+          : normY * innerH + playAreaOffsetY,
       });
 
       onReady({
@@ -369,11 +442,13 @@ export default function Court({ variant = "half", onReady, className, paintColor
         courtToCanvas,
         width: cssWidth,
         height: cssHeight,
-        playAreaHeight,
+        playAreaHeight: innerH,
         playAreaOffsetY,
+        playAreaOffsetX: oobLeft,
+        playAreaWidth: innerW,
       });
     }
-  }, [variant, onReady, paintColor]);
+  }, [variant, onReady, paintColor, flipped]);
 
   useEffect(() => {
     draw();

--- a/src/components/editor/SceneStrip.tsx
+++ b/src/components/editor/SceneStrip.tsx
@@ -208,6 +208,11 @@ function ContextMenu({
   const duplicateScene = useStore((s) => s.duplicateScene);
   const removeScene = useStore((s) => s.removeScene);
   const reorderScene = useStore((s) => s.reorderScene);
+  const setSceneFlipped = useStore((s) => s.setSceneFlipped);
+  const currentPlay = useStore((s) => s.currentPlay);
+  const scene = currentPlay?.scenes.find((s) => s.id === sceneId) ?? null;
+  const playFlipped = currentPlay?.flipped ?? false;
+  const sceneEffectiveFlipped = scene?.flipped != null ? scene.flipped : playFlipped;
   const ref = useRef<HTMLDivElement>(null);
 
   // Close when clicking outside
@@ -259,6 +264,16 @@ function ContextMenu({
           label: "Move Right",
           disabled: sceneIndex === totalScenes - 1,
           action: () => handle(() => reorderScene(sceneId, sceneIndex + 1)),
+        },
+        {
+          label: sceneEffectiveFlipped ? "Unflip scene" : "Flip scene",
+          disabled: false,
+          action: () => handle(() => setSceneFlipped(sceneId, !sceneEffectiveFlipped)),
+        },
+        {
+          label: "Reset scene flip",
+          disabled: scene?.flipped == null,
+          action: () => handle(() => setSceneFlipped(sceneId, null)),
         },
         {
           label: "Delete",

--- a/src/components/players/CourtWithPlayers.tsx
+++ b/src/components/players/CourtWithPlayers.tsx
@@ -88,21 +88,31 @@ function computeBallRadius(courtWidth: number): number {
 function normToPx(
   normX: number,
   normY: number,
-  width: number,
+  paWidth: number,
   paHeight: number,
   paOffsetY: number,
+  paOffsetX = 0,
+  flipped = false,
 ): { x: number; y: number } {
-  return { x: normX * width, y: normY * paHeight + paOffsetY };
+  return {
+    x: normX * paWidth + paOffsetX,
+    y: flipped ? (1 - normY) * paHeight + paOffsetY : normY * paHeight + paOffsetY,
+  };
 }
 
 function pxToNorm(
   px: number,
   py: number,
-  width: number,
+  paWidth: number,
   paHeight: number,
   paOffsetY: number,
+  paOffsetX = 0,
+  flipped = false,
 ): { x: number; y: number } {
-  return { x: px / width, y: (py - paOffsetY) / paHeight };
+  return {
+    x: (px - paOffsetX) / paWidth,
+    y: flipped ? 1 - (py - paOffsetY) / paHeight : (py - paOffsetY) / paHeight,
+  };
 }
 
 /** Create a default PlayerState array from normalised position defaults. */
@@ -145,9 +155,11 @@ export interface CourtWithPlayersProps {
   className?: string;
   /** When true, player/ball dragging is disabled and the store is not updated. */
   readOnly?: boolean;
+  /** When true, flips the court so the basket is at the top. */
+  flipped?: boolean;
 }
 
-export default function CourtWithPlayers({ sceneId, scene, variant = "half", className, readOnly = false }: CourtWithPlayersProps) {
+export default function CourtWithPlayers({ sceneId, scene, variant = "half", className, readOnly = false, flipped = false }: CourtWithPlayersProps) {
   const updatePlayerState  = useStore((s) => s.updatePlayerState);
   const updateBallState    = useStore((s) => s.updateBallState);
   const displayMode        = useStore((s) => s.playerDisplayMode);
@@ -155,7 +167,14 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
   const playColors         = useStore((s) => s.currentPlay?.colors);
 
   // Court layout reported by the Court canvas
-  const [courtSize, setCourtSize] = useState<{ width: number; height: number } | null>(null);
+  const [courtSize, setCourtSize] = useState<{
+    width: number;
+    height: number;
+    playAreaWidth: number;
+    playAreaHeight: number;
+    offsetX: number;
+    offsetY: number;
+  } | null>(null);
 
   // Local pixel-position state for smooth dragging (avoids round-tripping through store on every mousemove)
   const [offensePx, setOffensePx] = useState<PixelPlayer[] | null>(null);
@@ -174,10 +193,14 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
 
   /**
    * Play-area dimensions — the region where players live.
-   *   half court: { height: canvasH, offsetY: 0 }
-   *   full court: { height: canvasH/2, offsetY: canvasH/2 }  (near/bottom end)
+   *   half court: { height: innerH, offsetY: 0, offsetX: oobLeft }
+   *   full court: { height: innerH, offsetY: innerH+oobBot, offsetX: oobLeft }
    */
-  const playAreaRef = useRef<{ height: number; offsetY: number }>({ height: 0, offsetY: 0 });
+  const playAreaRef = useRef<{ height: number; offsetY: number; offsetX: number }>({ height: 0, offsetY: 0, offsetX: 0 });
+
+  // Always-current ref for flipped (readable in stable callbacks without causing re-creation)
+  const flippedRef = useRef(flipped);
+  flippedRef.current = flipped;
 
   // Track the last scene ID so we can reinitialise pixel positions on scene switch
   const prevSceneIdRef = useRef<string | null>(null);
@@ -221,20 +244,22 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
   // -------------------------------------------------------------------------
   const handleCourtReady = useCallback(
     (payload: CourtReadyPayload) => {
-      const { width, height, playAreaHeight, playAreaOffsetY } = payload;
+      const { width, height, playAreaHeight, playAreaOffsetY, playAreaOffsetX, playAreaWidth } = payload;
       const prevSize = courtSizeRef.current;
       const prevPlayArea = { ...playAreaRef.current };
       courtSizeRef.current = { width, height };
-      playAreaRef.current = { height: playAreaHeight, offsetY: playAreaOffsetY };
-      setCourtSize({ width, height });
+      playAreaRef.current = { height: playAreaHeight, offsetY: playAreaOffsetY, offsetX: playAreaOffsetX };
+      setCourtSize({ width, height, playAreaWidth, playAreaHeight, offsetX: playAreaOffsetX, offsetY: playAreaOffsetY });
+
+      const currentFlipped = flippedRef.current;
 
       // If size changed (resize) but we already have pixel positions, re-project
       if (prevSize && (prevSize.width !== width || prevSize.height !== height)) {
         setOffensePx((prev) =>
           prev
             ? prev.map((p) => {
-                const norm = pxToNorm(p.px, p.py, prevSize.width, prevPlayArea.height, prevPlayArea.offsetY);
-                const { x, y } = normToPx(norm.x, norm.y, width, playAreaHeight, playAreaOffsetY);
+                const norm = pxToNorm(p.px, p.py, prevPlayArea.height > 0 ? prevSize.width - 2 * prevPlayArea.offsetX : prevSize.width, prevPlayArea.height, prevPlayArea.offsetY, prevPlayArea.offsetX, currentFlipped);
+                const { x, y } = normToPx(norm.x, norm.y, playAreaWidth, playAreaHeight, playAreaOffsetY, playAreaOffsetX, currentFlipped);
                 return { ...p, px: x, py: y };
               })
             : null,
@@ -242,16 +267,16 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
         setDefensePx((prev) =>
           prev
             ? prev.map((p) => {
-                const norm = pxToNorm(p.px, p.py, prevSize.width, prevPlayArea.height, prevPlayArea.offsetY);
-                const { x, y } = normToPx(norm.x, norm.y, width, playAreaHeight, playAreaOffsetY);
+                const norm = pxToNorm(p.px, p.py, prevPlayArea.height > 0 ? prevSize.width - 2 * prevPlayArea.offsetX : prevSize.width, prevPlayArea.height, prevPlayArea.offsetY, prevPlayArea.offsetX, currentFlipped);
+                const { x, y } = normToPx(norm.x, norm.y, playAreaWidth, playAreaHeight, playAreaOffsetY, playAreaOffsetX, currentFlipped);
                 return { ...p, px: x, py: y };
               })
             : null,
         );
         setBallPx((prev) => {
           if (!prev) return null;
-          const norm = pxToNorm(prev.x, prev.y, prevSize.width, prevPlayArea.height, prevPlayArea.offsetY);
-          const { x, y } = normToPx(norm.x, norm.y, width, playAreaHeight, playAreaOffsetY);
+          const norm = pxToNorm(prev.x, prev.y, prevPlayArea.height > 0 ? prevSize.width - 2 * prevPlayArea.offsetX : prevSize.width, prevPlayArea.height, prevPlayArea.offsetY, prevPlayArea.offsetX, currentFlipped);
+          const { x, y } = normToPx(norm.x, norm.y, playAreaWidth, playAreaHeight, playAreaOffsetY, playAreaOffsetX, currentFlipped);
           return { x, y };
         });
         return;
@@ -274,68 +299,78 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
 
         setOffensePx(
           offenseStoreState.map((p) => {
-            const { x, y } = normToPx(p.x, p.y, width, playAreaHeight, playAreaOffsetY);
+            const { x, y } = normToPx(p.x, p.y, playAreaWidth, playAreaHeight, playAreaOffsetY, playAreaOffsetX, currentFlipped);
             return { position: p.position, px: x, py: y, visible: p.visible };
           }),
         );
         setDefensePx(
           defenseStoreState.map((p) => {
-            const { x, y } = normToPx(p.x, p.y, width, playAreaHeight, playAreaOffsetY);
+            const { x, y } = normToPx(p.x, p.y, playAreaWidth, playAreaHeight, playAreaOffsetY, playAreaOffsetX, currentFlipped);
             return { position: p.position, px: x, py: y, visible: p.visible };
           }),
         );
 
         // Ball initialisation
         const storeBall = currentScene?.ball ?? { ...BALL_DEFAULT, attachedTo: null };
-        const { x: ballX, y: ballY } = normToPx(storeBall.x, storeBall.y, width, playAreaHeight, playAreaOffsetY);
+        const { x: ballX, y: ballY } = normToPx(storeBall.x, storeBall.y, playAreaWidth, playAreaHeight, playAreaOffsetY, playAreaOffsetX, currentFlipped);
         setBallPx({ x: ballX, y: ballY });
         setBallAttachment(storeBall.attachedTo ?? null);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [], // Stable — never recreated. Scene changes handled by the useEffect below.
+    [], // Stable — never recreated. Scene/flip changes handled by useEffects below.
   );
 
   // -------------------------------------------------------------------------
-  // Reinitialise pixel positions when the active scene changes (user clicks a
-  // different scene in the SceneStrip). We track the previous scene ID via a
-  // ref so we only reinitialise on actual scene switches, not on every render.
+  // Reinitialise pixel positions when the active scene changes or when the
+  // court flip changes. We track the previous values via refs so we only
+  // reinitialise on actual changes, not on every render.
   // -------------------------------------------------------------------------
+  const prevFlippedRef = useRef<boolean>(false);
+
   useEffect(() => {
     const newSceneId = scene?.id ?? null;
-    // First render: positions are handled by handleCourtReady. Just record the ID.
+    const newFlipped = flipped ?? false;
+
+    // First render: positions are handled by handleCourtReady. Just record state.
     if (prevSceneIdRef.current === null) {
       prevSceneIdRef.current = newSceneId;
+      prevFlippedRef.current = newFlipped;
       return;
     }
-    // No scene change — visibility/position update within the same scene.
-    if (newSceneId === prevSceneIdRef.current) return;
+
+    const sceneChanged = newSceneId !== prevSceneIdRef.current;
+    const flipChanged  = newFlipped !== prevFlippedRef.current;
+
+    // No relevant change — bail
+    if (!sceneChanged && !flipChanged) return;
 
     prevSceneIdRef.current = newSceneId;
+    prevFlippedRef.current = newFlipped;
 
-    // Reinitialise pixel positions from the new scene's normalised data.
+    // Reinitialise pixel positions from the scene's normalised data.
     if (!scene || !courtSizeRef.current) return;
-    const { width } = courtSizeRef.current;
-    const { height: paH, offsetY: paOffY } = playAreaRef.current;
+    const { height: paH, offsetY: paOffY, offsetX: paOffX } = playAreaRef.current;
+    const paW = courtSizeRef.current.width - 2 * paOffX;
 
     setOffensePx(
       scene.players.offense.map((p) => {
-        const { x, y } = normToPx(p.x, p.y, width, paH, paOffY);
+        const { x, y } = normToPx(p.x, p.y, paW, paH, paOffY, paOffX, newFlipped);
         return { position: p.position, px: x, py: y, visible: p.visible };
       }),
     );
     setDefensePx(
       scene.players.defense.map((p) => {
-        const { x, y } = normToPx(p.x, p.y, width, paH, paOffY);
+        const { x, y } = normToPx(p.x, p.y, paW, paH, paOffY, paOffX, newFlipped);
         return { position: p.position, px: x, py: y, visible: p.visible };
       }),
     );
 
     const storeBall = scene.ball ?? { ...BALL_DEFAULT, attachedTo: null };
-    const { x: ballX, y: ballY } = normToPx(storeBall.x, storeBall.y, width, paH, paOffY);
+    const { x: ballX, y: ballY } = normToPx(storeBall.x, storeBall.y, paW, paH, paOffY, paOffX, newFlipped);
     setBallPx({ x: ballX, y: ballY });
     setBallAttachment(storeBall.attachedTo ?? null);
-  }, [scene]);
+  }, [scene, flipped]);
 
   // -------------------------------------------------------------------------
   // Drag handlers — players
@@ -355,7 +390,9 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
         if (!prev) return prev;
         const updated = prev.map((p) => (p.position === position ? { ...p, px: newCx, py: newCy } : p));
         if (sceneId && courtSizeRef.current) {
-          const { x, y } = pxToNorm(newCx, newCy, courtSizeRef.current.width, playAreaRef.current.height, playAreaRef.current.offsetY);
+          const { height: paH, offsetY: paOffY, offsetX: paOffX } = playAreaRef.current;
+          const paW = courtSizeRef.current.width - 2 * paOffX;
+          const { x, y } = pxToNorm(newCx, newCy, paW, paH, paOffY, paOffX, flippedRef.current);
           // Read visible from the scene prop (source of truth) to avoid overwriting
           // a visibility toggle with a stale value from local pixel state.
           const scenePlayer = offenseVisible?.find((sp) => sp.position === position);
@@ -382,7 +419,9 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
         if (!prev) return prev;
         const updated = prev.map((p) => (p.position === position ? { ...p, px: newCx, py: newCy } : p));
         if (sceneId && courtSizeRef.current) {
-          const { x, y } = pxToNorm(newCx, newCy, courtSizeRef.current.width, playAreaRef.current.height, playAreaRef.current.offsetY);
+          const { height: paH, offsetY: paOffY, offsetX: paOffX } = playAreaRef.current;
+          const paW = courtSizeRef.current.width - 2 * paOffX;
+          const { x, y } = pxToNorm(newCx, newCy, paW, paH, paOffY, paOffX, flippedRef.current);
           // Read visible from the scene prop (source of truth) to avoid overwriting
           // a visibility toggle with a stale value from local pixel state.
           const scenePlayer = defenseVisible?.find((sp) => sp.position === position);
@@ -464,13 +503,9 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
         // Free position becomes player position (for re-projection on resize)
         setBallPx({ x: nearest.px, y: nearest.py });
         if (sceneId && courtSizeRef.current) {
-          const { x, y } = pxToNorm(
-            nearest.px,
-            nearest.py,
-            courtSizeRef.current.width,
-            playAreaRef.current.height,
-            playAreaRef.current.offsetY,
-          );
+          const { height: paH, offsetY: paOffY, offsetX: paOffX } = playAreaRef.current;
+          const paW = courtSizeRef.current.width - 2 * paOffX;
+          const { x, y } = pxToNorm(nearest.px, nearest.py, paW, paH, paOffY, paOffX, flippedRef.current);
           newBallState = { x, y, attachedTo: { side: nearest.side, position: nearest.position } };
         } else {
           return;
@@ -480,7 +515,9 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
         setBallAttachment(null);
         setBallPx({ x: newCx, y: newCy });
         if (sceneId && courtSizeRef.current) {
-          const { x, y } = pxToNorm(newCx, newCy, courtSizeRef.current.width, playAreaRef.current.height, playAreaRef.current.offsetY);
+          const { height: paH, offsetY: paOffY, offsetX: paOffX } = playAreaRef.current;
+          const paW = courtSizeRef.current.width - 2 * paOffX;
+          const { x, y } = pxToNorm(newCx, newCy, paW, paH, paOffY, paOffX, flippedRef.current);
           newBallState = { x, y, attachedTo: null };
         } else {
           return;
@@ -498,8 +535,9 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
 
   const allPlayers = buildPlayerList(offensePx, defensePx);
 
-  const tokenRadius = courtSize ? computeTokenRadius(courtSize.width) : undefined;
-  const ballRadius = courtSize ? computeBallRadius(courtSize.width) : undefined;
+  // Use the inner court (play area) width for proportional token sizing
+  const tokenRadius = courtSize ? computeTokenRadius(courtSize.playAreaWidth) : undefined;
+  const ballRadius = courtSize ? computeBallRadius(courtSize.playAreaWidth) : undefined;
   const ballAttachOffsetY = tokenRadius && ballRadius ? -(tokenRadius + ballRadius + 2) : BALL_ATTACH_OFFSET_Y;
 
   const effectiveBall = getEffectiveBallPx(ballAttachment, offensePx, defensePx, ballPx, ballAttachOffsetY);
@@ -507,7 +545,7 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
   return (
     <div className={`relative ${className ?? "w-full"}`}>
       {/* Court canvas */}
-      <Court variant={variant} onReady={handleCourtReady} className="w-full" paintColor={playColors?.offense} />
+      <Court variant={variant} onReady={handleCourtReady} className="w-full" paintColor={playColors?.offense} flipped={flipped} />
 
       {/* SVG player + ball overlay — same dimensions as the canvas */}
       {courtSize && (
@@ -524,6 +562,7 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
           viewBox={`0 0 ${courtSize.width} ${courtSize.height}`}
           aria-hidden="true"
         >
+
           {/* Enable pointer events only on the tokens themselves (disabled in readOnly mode) */}
           <g style={{ pointerEvents: readOnly ? "none" : "all" }}>
             {/* Defensive players (rendered first = underneath offensive) */}
@@ -600,8 +639,13 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
         <AnnotationLayer
           width={courtSize.width}
           height={courtSize.height}
+          playAreaWidth={courtSize.playAreaWidth}
+          playAreaHeight={courtSize.playAreaHeight}
+          offsetX={courtSize.offsetX}
+          offsetY={courtSize.offsetY}
           sceneId={sceneId ?? null}
           players={allPlayers}
+          flipped={flipped}
         />
       )}
     </div>

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -66,6 +66,10 @@ export interface AppStore {
     patch: Partial<Pick<Play, "title" | "description" | "category" | "tags" | "courtType">>,
   ) => void;
   updatePlayColors: (colors: PlayColors) => void;
+  /** Toggle or set the play-level court orientation (basket north/south). */
+  setPlayFlipped: (flipped: boolean) => void;
+  /** Override the court orientation for a specific scene (null = inherit from play). */
+  setSceneFlipped: (sceneId: string, flipped: boolean | null) => void;
 
   // Undo / Redo (issue #83)
   undo: () => void;
@@ -343,6 +347,22 @@ export const useStore = create<AppStore>()(
         return { currentPlay: { ...state.currentPlay, colors, updatedAt: new Date() } };
       }),
 
+    setPlayFlipped: (flipped) =>
+      set((state) => {
+        if (!state.currentPlay) return state;
+        return { currentPlay: { ...state.currentPlay, flipped, updatedAt: new Date() } };
+      }),
+
+    setSceneFlipped: (sceneId, flipped) => {
+      const state = get();
+      const snapshot = captureSnapshot(state);
+      if (snapshot) useHistoryStore.getState().pushSnapshot(snapshot);
+      set((s) => {
+        if (!s.currentPlay) return s;
+        return { currentPlay: withUpdatedScene(s.currentPlay, sceneId, (sc) => ({ ...sc, flipped })) };
+      });
+    },
+
     // -----------------------------------------------------------------------
     // Scene management
     // -----------------------------------------------------------------------
@@ -515,6 +535,15 @@ export const useStore = create<AppStore>()(
                 p.position === player.position ? player : p,
               ),
             },
+            // Feature 1: keep annotation origins in sync with the moved player
+            timingGroups: sc.timingGroups.map((g) => ({
+              ...g,
+              annotations: g.annotations.map((ann) =>
+                ann.fromPlayer?.side === side && ann.fromPlayer.position === player.position
+                  ? { ...ann, from: { x: player.x, y: player.y } }
+                  : ann,
+              ),
+            })),
           })),
         };
       });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -61,6 +61,8 @@ export interface Scene {
   };
   ball: BallState;
   timingGroups: TimingGroup[];
+  /** undefined/null = inherit play.flipped; boolean = override for this scene only */
+  flipped?: boolean | null;
 }
 
 export interface RosterPlayer {
@@ -108,6 +110,8 @@ export interface Play {
   scenes: Scene[];
   /** Optional custom colors for offensive and defensive player tokens. */
   colors?: PlayColors;
+  /** When true, basket is at the top (north) instead of the default south. */
+  flipped?: boolean;
 }
 
 export interface User {


### PR DESCRIPTION
## Summary

- **Feature 1 — Arrow origins follow player movement**: `updatePlayerState` now patches `ann.from` for any annotation whose `fromPlayer` matches the moved player. Arrow tails stay anchored to players when dragged.

- **Feature 2 — Flip court orientation**: Play-level `flipped` flag (with per-scene override) flips the basket north/south. ↕ button in the editor header toggles it; right-click a scene for a scene-level override or reset. The flip is a pure visual canvas transform; coordinate conversion in `CourtWithPlayers` and `AnnotationLayer` compensates so player tokens and annotations render correctly.

- **Feature 3 — Out-of-bounds sideline space**: The canvas now shows floor colour on both sides and below the court boundary. `OOB_SIDE_FRAC=0.06` and `OOB_BOTTOM_FRAC=0.07` exported constants control the margin size. All coordinate conversions updated to account for the inner court play-area offset.

## Test plan

- [ ] Draw an arrow from a player. Drag that player — the arrow tail should follow. Endpoint stays fixed.
- [ ] Click ↕ in the header → basket moves to top, players/arrows render correctly.
- [ ] Right-click a scene → "Flip scene" flips just that scene; "Reset scene flip" reverts it.
- [ ] Confirm court shows visible floor area on sides and bottom baseline.
- [ ] Drag players to the edge of the inner court — coords save and reload correctly.
- [ ] Full court variant still renders both ends; flip works on full court too.
- [ ] `npm run build` — no TypeScript errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)