### PR TITLE
Fix #144: Hand-off (DHO) annotation type

### DIFF
--- a/src/components/annotations/AnnotationLayer.tsx
+++ b/src/components/annotations/AnnotationLayer.tsx
@@ -294,6 +294,60 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
     );
   }
 
+  if (type === "handoff") {
+    // Dribble hand-off (DHO): dashed line from ball-handler to receiver with
+    // two small perpendicular tick marks near the delivery point (to endpoint).
+    // Standard DHO notation used in FastDraw / Synergy coaching diagrams.
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const ux = len > 0 ? dx / len : 1;
+    const uy = len > 0 ? dy / len : 0;
+    // Perpendicular direction
+    const px2 = -uy;
+    const py2 = ux;
+    // Tick bar length
+    const tickLen = 9;
+    // First tick: at 85% along the line
+    const t1 = 0.85;
+    const t1x = from.x + dx * t1;
+    const t1y = from.y + dy * t1;
+    // Second tick: at 72% along the line
+    const t2 = 0.72;
+    const t2x = from.x + dx * t2;
+    const t2y = from.y + dy * t2;
+    return (
+      <g onClick={handleClick} style={hitStyle}>
+        {selectRing}
+        {/* Invisible wide hit-area */}
+        <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke="transparent" strokeWidth={14} />
+        {/* Dashed body line */}
+        <line
+          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+          stroke="#0369A1"
+          strokeWidth={2.5}
+          strokeLinecap="round"
+          strokeDasharray="6 4"
+        />
+        {/* First perpendicular tick mark */}
+        <line
+          x1={t1x + px2 * tickLen} y1={t1y + py2 * tickLen}
+          x2={t1x - px2 * tickLen} y2={t1y - py2 * tickLen}
+          stroke="#0369A1" strokeWidth={2.5} strokeLinecap="round"
+        />
+        {/* Second perpendicular tick mark */}
+        <line
+          x1={t2x + px2 * tickLen} y1={t2y + py2 * tickLen}
+          x2={t2x - px2 * tickLen} y2={t2y - py2 * tickLen}
+          stroke="#0369A1" strokeWidth={2.5} strokeLinecap="round"
+        />
+        {/* Direction arrow at the receiver end */}
+        {headPoints && <polygon points={headPoints} fill="#0369A1" />}
+        {stepBadge}
+      </g>
+    );
+  }
+
   return null;
 }
 
@@ -382,6 +436,39 @@ function PreviewAnnotation({
     return (
       <g pointerEvents="none" opacity={0.7}>
         <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke="#D97706" strokeWidth={2} strokeLinecap="round" strokeDasharray="4 4" />
+      </g>
+    );
+  }
+
+  if (tool === "handoff") {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const ux = len > 0 ? dx / len : 1;
+    const uy = len > 0 ? dy / len : 0;
+    const px2 = -uy;
+    const py2 = ux;
+    const tickLen = 9;
+    const t1 = 0.85;
+    const t1x = from.x + dx * t1;
+    const t1y = from.y + dy * t1;
+    const t2 = 0.72;
+    const t2x = from.x + dx * t2;
+    const t2y = from.y + dy * t2;
+    return (
+      <g pointerEvents="none" opacity={0.7}>
+        <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke="#0369A1" strokeWidth={2.5} strokeLinecap="round" strokeDasharray="6 4" />
+        <line
+          x1={t1x + px2 * tickLen} y1={t1y + py2 * tickLen}
+          x2={t1x - px2 * tickLen} y2={t1y - py2 * tickLen}
+          stroke="#0369A1" strokeWidth={2.5} strokeLinecap="round"
+        />
+        <line
+          x1={t2x + px2 * tickLen} y1={t2y + py2 * tickLen}
+          x2={t2x - px2 * tickLen} y2={t2y - py2 * tickLen}
+          stroke="#0369A1" strokeWidth={2.5} strokeLinecap="round"
+        />
+        {headPoints && <polygon points={headPoints} fill="#0369A1" opacity={0.8} />}
       </g>
     );
   }

--- a/src/components/editor/DrawingToolsPanel.tsx
+++ b/src/components/editor/DrawingToolsPanel.tsx
@@ -158,6 +158,30 @@ function GuardIcon({ active }: { active: boolean }) {
   );
 }
 
+/** Hand-off (DHO) tool icon — short dashed line with double perpendicular tick marks */
+function HandoffIcon({ active }: { active: boolean }) {
+  const c = active ? ACTIVE_COLOR : IDLE_COLOR;
+  return (
+    <svg viewBox="0 0 28 28" width={22} height={22} aria-hidden="true">
+      {/* Dashed line from ball-handler to receiver */}
+      <line
+        x1="5"
+        y1="23"
+        x2="22"
+        y2="7"
+        stroke={c}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeDasharray="3 3"
+      />
+      {/* First perpendicular tick at delivery point */}
+      <line x1="17" y1="8" x2="21" y2="12" stroke={c} strokeWidth={2.5} strokeLinecap="round" />
+      {/* Second perpendicular tick (offset along line) */}
+      <line x1="14" y1="11" x2="18" y2="15" stroke={c} strokeWidth={2.5} strokeLinecap="round" />
+    </svg>
+  );
+}
+
 /** Eraser tool icon */
 function EraserIcon({ active }: { active: boolean }) {
   const c = active ? ACTIVE_COLOR : IDLE_COLOR;
@@ -188,6 +212,7 @@ const TOOLS: ToolDef[] = [
   { id: "screen",   label: "Screen",   shortcut: "S", Icon: ScreenIcon   },
   { id: "cut",      label: "Cut",      shortcut: "C", Icon: CutIcon      },
   { id: "guard",    label: "Guard",    shortcut: "G", Icon: GuardIcon    },
+  { id: "handoff",  label: "Hand-off", shortcut: "H", Icon: HandoffIcon  },
   { id: "eraser",   label: "Eraser",   shortcut: "E", Icon: EraserIcon   },
 ];
 
@@ -200,6 +225,7 @@ export const TOOL_CURSOR: Record<DrawingTool, string> = {
   screen:   "crosshair",
   cut:      "crosshair",
   guard:    "crosshair",
+  handoff:  "crosshair",
   eraser:   "cell",
 };
 

--- a/src/components/editor/ShortcutsOverlay.tsx
+++ b/src/components/editor/ShortcutsOverlay.tsx
@@ -32,6 +32,7 @@ const SECTIONS: ShortcutSection[] = [
       { keys: ["S"], description: "Screen / pick" },
       { keys: ["C"], description: "Cut (dashed arrow)" },
       { keys: ["G"], description: "Guard assignment (defender → offensive player)" },
+      { keys: ["H"], description: "Hand-off / DHO (ball-handler → receiver)" },
       { keys: ["E"], description: "Eraser" },
       { keys: ["Esc"], description: "Back to Select" },
     ],

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -47,6 +47,7 @@ const TOOL_KEY_MAP: Record<string, DrawingTool> = {
   s: "screen",
   c: "cut",
   g: "guard",
+  h: "handoff",
   e: "eraser",
 };
 

--- a/src/lib/exportPNG.ts
+++ b/src/lib/exportPNG.ts
@@ -450,6 +450,66 @@ function drawAnnotation(
     ctx.stroke();
     ctx.setLineDash([]);
     drawArrowHead(ctx, from.x, from.y, to.x, to.y, arrowSize, "#DC2626");
+    return;
+  }
+
+  if (type === "guard") {
+    ctx.beginPath();
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
+    ctx.strokeStyle = "#D97706";
+    ctx.lineWidth = 2 * scale;
+    ctx.globalAlpha = 0.85;
+    ctx.setLineDash([4 * scale, 4 * scale]);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.globalAlpha = 1;
+    return;
+  }
+
+  if (type === "handoff") {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const ux = len > 0 ? dx / len : 1;
+    const uy = len > 0 ? dy / len : 0;
+    // Perpendicular direction
+    const px2 = -uy;
+    const py2 = ux;
+    const tickLen = 9 * scale;
+    // Tick positions along the line
+    const t1 = 0.85;
+    const t1x = from.x + dx * t1;
+    const t1y = from.y + dy * t1;
+    const t2 = 0.72;
+    const t2x = from.x + dx * t2;
+    const t2y = from.y + dy * t2;
+
+    ctx.strokeStyle = "#0369A1";
+    ctx.lineWidth = 2.5 * scale;
+    ctx.lineCap = "round";
+
+    // Dashed body line
+    ctx.setLineDash([6 * scale, 4 * scale]);
+    ctx.beginPath();
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Tick marks
+    ctx.beginPath();
+    ctx.moveTo(t1x + px2 * tickLen, t1y + py2 * tickLen);
+    ctx.lineTo(t1x - px2 * tickLen, t1y - py2 * tickLen);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(t2x + px2 * tickLen, t2y + py2 * tickLen);
+    ctx.lineTo(t2x - px2 * tickLen, t2y - py2 * tickLen);
+    ctx.stroke();
+
+    // Arrowhead
+    drawArrowHead(ctx, from.x, from.y, to.x, to.y, arrowSize, "#0369A1");
   }
 }
 

--- a/src/lib/exportPdf.ts
+++ b/src/lib/exportPdf.ts
@@ -59,6 +59,8 @@ const ANN_COLOR: Record<string, string> = {
   pass:     "#059669",
   screen:   "#7C3AED",
   cut:      "#DC2626",
+  guard:    "#D97706",
+  handoff:  "#0369A1",
 };
 
 // ---------------------------------------------------------------------------
@@ -240,6 +242,52 @@ function drawAnnotation(
     ctx.lineTo(tx, ty);
     ctx.stroke();
     ctx.setLineDash([]);
+    drawArrowHead(ctx, tx, ty, fx, fy, ANN_ARROW_SIZE);
+
+  } else if (ann.type === "guard") {
+    ctx.globalAlpha = 0.85;
+    ctx.setLineDash([ANN_LINE_W * 4, ANN_LINE_W * 4]);
+    ctx.beginPath();
+    ctx.moveTo(fx, fy);
+    ctx.lineTo(tx, ty);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.globalAlpha = 1;
+
+  } else if (ann.type === "handoff") {
+    const dx = tx - fx;
+    const dy = ty - fy;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const ux = len > 0 ? dx / len : 1;
+    const uy = len > 0 ? dy / len : 0;
+    const px2 = -uy;
+    const py2 = ux;
+    const tickLen = ANN_ARROW_SIZE * 0.75;
+    const t1 = 0.85;
+    const t1x = fx + dx * t1;
+    const t1y = fy + dy * t1;
+    const t2 = 0.72;
+    const t2x = fx + dx * t2;
+    const t2y = fy + dy * t2;
+
+    ctx.setLineDash([ANN_LINE_W * 3, ANN_LINE_W * 2]);
+    ctx.beginPath();
+    ctx.moveTo(fx, fy);
+    ctx.lineTo(tx, ty);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Tick marks
+    ctx.beginPath();
+    ctx.moveTo(t1x + px2 * tickLen, t1y + py2 * tickLen);
+    ctx.lineTo(t1x - px2 * tickLen, t1y - py2 * tickLen);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(t2x + px2 * tickLen, t2y + py2 * tickLen);
+    ctx.lineTo(t2x - px2 * tickLen, t2y - py2 * tickLen);
+    ctx.stroke();
+
     drawArrowHead(ctx, tx, ty, fx, fy, ANN_ARROW_SIZE);
   }
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -29,6 +29,7 @@ export type DrawingTool =
   | "screen"
   | "cut"
   | "guard"
+  | "handoff"
   | "eraser";
 
 export type PlaybackSpeed = 0.5 | 1 | 1.5 | 2;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,7 +14,7 @@ export type Category =
   | "oob"
   | "special";
 
-export type AnnotationType = "movement" | "dribble" | "pass" | "screen" | "cut" | "guard";
+export type AnnotationType = "movement" | "dribble" | "pass" | "screen" | "cut" | "guard" | "handoff";
 
 export interface Point {
   x: number;


### PR DESCRIPTION
## Summary

- Adds a new `handoff` annotation type for diagramming dribble hand-offs (DHO) — the standard notation used in FastDraw and Synergy coaching software
- Visual: sky-blue dashed line from ball-handler to receiver with two small perpendicular tick marks ("double pipe") near the delivery point, plus an arrowhead at the receiver
- Keyboard shortcut: `H` — activates the Hand-off drawing tool
- Rendering consistent across live editor, PNG export, and PDF export

## What Changed

| File | Change |
|---|---|
| `src/lib/types.ts` | Added `"handoff"` to `AnnotationType` union |
| `src/lib/store.ts` | Added `"handoff"` to `DrawingTool` union |
| `src/components/editor/DrawingToolsPanel.tsx` | `HandoffIcon` SVG, TOOLS entry (label "Hand-off", shortcut H), TOOL_CURSOR entry |
| `src/components/annotations/AnnotationLayer.tsx` | Full rendered branch + live-preview branch for handoff |
| `src/hooks/useKeyboardShortcuts.ts` | Maps `h` key to `"handoff"` tool |
| `src/components/editor/ShortcutsOverlay.tsx` | Added `H — Hand-off / DHO` entry in Tools section |
| `src/lib/exportPNG.ts` | Added handoff rendering (dashed line + ticks + arrowhead); also added previously-missing `guard` annotation rendering |
| `src/lib/exportPdf.ts` | Added `guard` and `handoff` to the colour map and rendering branches |

## Test plan

- [ ] Open any play in the editor — confirm "Hand-off" tool appears in the drawing panel between Guard and Eraser
- [ ] Press `H` — confirm the Hand-off tool is selected
- [ ] Draw a hand-off annotation between two players — dashed sky-blue line appears with two perpendicular tick bars and an arrowhead
- [ ] Live preview (while dragging) shows the same visual
- [ ] Press `?` — confirm "H — Hand-off / DHO" appears in the keyboard shortcuts overlay
- [ ] Export scene as PNG — handoff annotation renders correctly
- [ ] Export play as PDF — handoff annotation renders correctly
- [ ] Undo/redo of handoff annotation works correctly (uses existing `addAnnotation`/`removeAnnotation` which go through `withHistory`)
- [ ] `npm run build` passes with no TypeScript errors

## Notes

This PR should be **squash-merged**.

Resolves #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)