### PR TITLE
Fix #142: Curved annotation lines (quadratic bezier arcs)

### DIFF
--- a/src/components/annotations/AnnotationLayer.tsx
+++ b/src/components/annotations/AnnotationLayer.tsx
@@ -29,6 +29,7 @@ import { useStore, selectEditorScene, selectAllAnnotations } from "@/lib/store";
 import type { DrawingTool } from "@/lib/store";
 import type { Annotation, Point } from "@/lib/types";
 import { TOOL_CURSOR } from "@/components/editor/DrawingToolsPanel";
+import { useHistoryStore } from "@/lib/history";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -69,6 +70,67 @@ function arrowHead(
   return `${tipX},${tipY} ${baseX + px * w},${baseY + py * w} ${baseX - px * w},${baseY - py * w}`;
 }
 
+/**
+ * Build an SVG quadratic bezier path string from pixel from/to/control points.
+ * Falls back to a straight line if no control point.
+ */
+function bezierPath(from: Point, to: Point, cp?: Point): string {
+  if (!cp) return `M ${from.x},${from.y} L ${to.x},${to.y}`;
+  return `M ${from.x},${from.y} Q ${cp.x},${cp.y} ${to.x},${to.y}`;
+}
+
+/**
+ * Compute a point on a quadratic bezier at parameter t.
+ * When cp is undefined, returns linear interpolation.
+ */
+function bezierPoint(from: Point, to: Point, t: number, cp?: Point): Point {
+  if (!cp) {
+    return { x: from.x + (to.x - from.x) * t, y: from.y + (to.y - from.y) * t };
+  }
+  const mt = 1 - t;
+  return {
+    x: mt * mt * from.x + 2 * mt * t * cp.x + t * t * to.x,
+    y: mt * mt * from.y + 2 * mt * t * cp.y + t * t * to.y,
+  };
+}
+
+/**
+ * Compute the tangent direction at the end of a quadratic bezier (t=1).
+ * Returns a vector from the point just before the end toward the end —
+ * used to orient the arrowhead correctly on curved lines.
+ */
+function bezierEndTangent(from: Point, to: Point, cp?: Point): { ux: number; uy: number } {
+  // Tangent at t=1: direction from cp to to (or from to to for straight lines)
+  const tail = cp ?? from;
+  const dx = to.x - tail.x;
+  const dy = to.y - tail.y;
+  const len = Math.sqrt(dx * dx + dy * dy);
+  if (len < 0.001) return { ux: 1, uy: 0 };
+  return { ux: dx / len, uy: dy / len };
+}
+
+/**
+ * Arrowhead polygon string using bezier tangent direction at the endpoint.
+ */
+function arrowHeadBezier(to: Point, from: Point, cp: Point | undefined, size: number = 12): string {
+  const { ux, uy } = bezierEndTangent(from, to, cp);
+  // Perpendicular
+  const px = -uy;
+  const py = ux;
+  const baseX = to.x - ux * size;
+  const baseY = to.y - uy * size;
+  const w = size * 0.45;
+  return `${to.x},${to.y} ${baseX + px * w},${baseY + py * w} ${baseX - px * w},${baseY - py * w}`;
+}
+
+/**
+ * Default control point: offset perpendicular to the line midpoint by a small amount.
+ * Used when the user has not yet dragged the handle.
+ */
+function defaultControlPoint(from: Point, to: Point): Point {
+  return { x: (from.x + to.x) / 2, y: (from.y + to.y) / 2 };
+}
+
 interface RenderedAnnotationProps {
   ann: Annotation;
   selected: boolean;
@@ -99,11 +161,18 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
   });
   const from = normToSvg(ann.from.x, ann.from.y);
   const to   = normToSvg(ann.to.x,   ann.to.y);
+
+  // Control point (bezier curve support)
+  const cp: Point | undefined = ann.controlPoints.length > 0
+    ? normToSvg(ann.controlPoints[0].x, ann.controlPoints[0].y)
+    : undefined;
+
   const hitStyle: React.CSSProperties = { cursor: "pointer", pointerEvents: "stroke" };
 
-  // Step badge — small circle at the midpoint of the annotation
-  const midX = (from.x + to.x) / 2;
-  const midY = (from.y + to.y) / 2;
+  // Step badge — small circle at the midpoint of the annotation (on the curve)
+  const mid = bezierPoint(from, to, 0.5, cp);
+  const midX = mid.x;
+  const midY = mid.y;
   const stepBadge = showStepBadge && step !== undefined ? (
     <g pointerEvents="none">
       <circle cx={midX} cy={midY} r={9} fill="#3B82F6" opacity={0.9} />
@@ -121,7 +190,11 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
     </g>
   ) : null;
 
-  const headPoints = arrowHead(to.x, to.y, from.x, from.y);
+  // For straight lines use legacy arrowHead; for bezier use bezier tangent
+  const headPoints = cp
+    ? arrowHeadBezier(to, from, cp)
+    : arrowHead(to.x, to.y, from.x, from.y);
+
   const selectRing = selected ? (
     <rect
       x={Math.min(from.x, to.x) - 6}
@@ -143,19 +216,18 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
   };
 
   if (type === "movement") {
+    const d = bezierPath(from, to, cp);
     return (
       <g onClick={handleClick} style={hitStyle}>
         {selectRing}
         {/* Invisible wide hit-area */}
-        <line
-          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
-          stroke="transparent" strokeWidth={14}
-        />
-        <line
-          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+        <path d={d} stroke="transparent" strokeWidth={14} fill="none" />
+        <path
+          d={d}
           stroke="#1E3A5F"
           strokeWidth={2.5}
           strokeLinecap="round"
+          fill="none"
         />
         {headPoints && (
           <polygon points={headPoints} fill="#1E3A5F" />
@@ -166,7 +238,28 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
   }
 
   if (type === "dribble") {
-    // Build zigzag path
+    if (cp) {
+      // Curved dribble: render as bezier path (smooth) + arrowhead
+      const d = bezierPath(from, to, cp);
+      return (
+        <g onClick={handleClick} style={hitStyle}>
+          {selectRing}
+          <path d={d} stroke="transparent" strokeWidth={14} fill="none" />
+          <path
+            d={d}
+            stroke="#1E3A5F"
+            strokeWidth={2.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeDasharray="5 4"
+            fill="none"
+          />
+          {headPoints && <polygon points={headPoints} fill="#1E3A5F" />}
+          {stepBadge}
+        </g>
+      );
+    }
+    // Straight dribble: zigzag path
     const dx = to.x - from.x;
     const dy = to.y - from.y;
     const len = Math.sqrt(dx * dx + dy * dy);
@@ -202,19 +295,18 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
   }
 
   if (type === "pass") {
-    // Straight line with solid triangle tip — rendered slightly thinner / different colour
+    // Straight/curved line with solid triangle tip
+    const d = bezierPath(from, to, cp);
     return (
       <g onClick={handleClick} style={hitStyle}>
         {selectRing}
-        <line
-          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
-          stroke="transparent" strokeWidth={14}
-        />
-        <line
-          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+        <path d={d} stroke="transparent" strokeWidth={14} fill="none" />
+        <path
+          d={d}
           stroke="#059669"
           strokeWidth={2}
           strokeLinecap="round"
+          fill="none"
         />
         {headPoints && <polygon points={headPoints} fill="#059669" />}
         {stepBadge}
@@ -250,19 +342,18 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
   }
 
   if (type === "cut") {
+    const d = bezierPath(from, to, cp);
     return (
       <g onClick={handleClick} style={hitStyle}>
         {selectRing}
-        <line
-          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
-          stroke="transparent" strokeWidth={14}
-        />
-        <line
-          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+        <path d={d} stroke="transparent" strokeWidth={14} fill="none" />
+        <path
+          d={d}
           stroke="#DC2626"
           strokeWidth={2.5}
           strokeLinecap="round"
           strokeDasharray="7 5"
+          fill="none"
         />
         {headPoints && <polygon points={headPoints} fill="#DC2626" />}
         {stepBadge}
@@ -274,20 +365,19 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
     // Guard assignment: dashed line from defender to offensive player.
     // Rendered in amber/orange to be visually distinct from cut (red dashed)
     // and from movement (solid navy). No arrowhead — it is a static assignment link.
+    const d = bezierPath(from, to, cp);
     return (
       <g onClick={handleClick} style={hitStyle}>
         {selectRing}
-        <line
-          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
-          stroke="transparent" strokeWidth={14}
-        />
-        <line
-          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+        <path d={d} stroke="transparent" strokeWidth={14} fill="none" />
+        <path
+          d={d}
           stroke="#D97706"
           strokeWidth={2}
           strokeLinecap="round"
           strokeDasharray="4 4"
           opacity={0.85}
+          fill="none"
         />
         {stepBadge}
       </g>
@@ -298,47 +388,48 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
     // Dribble hand-off (DHO): dashed line from ball-handler to receiver with
     // two small perpendicular tick marks near the delivery point (to endpoint).
     // Standard DHO notation used in FastDraw / Synergy coaching diagrams.
-    const dx = to.x - from.x;
-    const dy = to.y - from.y;
-    const len = Math.sqrt(dx * dx + dy * dy);
-    const ux = len > 0 ? dx / len : 1;
-    const uy = len > 0 ? dy / len : 0;
-    // Perpendicular direction
-    const px2 = -uy;
-    const py2 = ux;
-    // Tick bar length
+    const d = bezierPath(from, to, cp);
     const tickLen = 9;
-    // First tick: at 85% along the line
-    const t1 = 0.85;
-    const t1x = from.x + dx * t1;
-    const t1y = from.y + dy * t1;
-    // Second tick: at 72% along the line
-    const t2 = 0.72;
-    const t2x = from.x + dx * t2;
-    const t2y = from.y + dy * t2;
+    // Tick positions along the path (bezier-aware)
+    const tick1 = bezierPoint(from, to, 0.85, cp);
+    const tick2 = bezierPoint(from, to, 0.72, cp);
+    // Tangent at t=0.85 and t=0.72 for perpendicular tick orientation
+    const tangent1Before = bezierPoint(from, to, 0.83, cp);
+    const tangent2Before = bezierPoint(from, to, 0.70, cp);
+    const getTick = (pt: Point, before: Point) => {
+      const ddx = pt.x - before.x;
+      const ddy = pt.y - before.y;
+      const dlen = Math.sqrt(ddx * ddx + ddy * ddy);
+      const pux = dlen > 0 ? -ddy / dlen : 0;
+      const puy = dlen > 0 ? ddx / dlen : 1;
+      return { pux, puy };
+    };
+    const { pux: pux1, puy: puy1 } = getTick(tick1, tangent1Before);
+    const { pux: pux2, puy: puy2 } = getTick(tick2, tangent2Before);
     return (
       <g onClick={handleClick} style={hitStyle}>
         {selectRing}
         {/* Invisible wide hit-area */}
-        <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke="transparent" strokeWidth={14} />
+        <path d={d} stroke="transparent" strokeWidth={14} fill="none" />
         {/* Dashed body line */}
-        <line
-          x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+        <path
+          d={d}
           stroke="#0369A1"
           strokeWidth={2.5}
           strokeLinecap="round"
           strokeDasharray="6 4"
+          fill="none"
         />
         {/* First perpendicular tick mark */}
         <line
-          x1={t1x + px2 * tickLen} y1={t1y + py2 * tickLen}
-          x2={t1x - px2 * tickLen} y2={t1y - py2 * tickLen}
+          x1={tick1.x + pux1 * tickLen} y1={tick1.y + puy1 * tickLen}
+          x2={tick1.x - pux1 * tickLen} y2={tick1.y - puy1 * tickLen}
           stroke="#0369A1" strokeWidth={2.5} strokeLinecap="round"
         />
         {/* Second perpendicular tick mark */}
         <line
-          x1={t2x + px2 * tickLen} y1={t2y + py2 * tickLen}
-          x2={t2x - px2 * tickLen} y2={t2y - py2 * tickLen}
+          x1={tick2.x + pux2 * tickLen} y1={tick2.y + puy2 * tickLen}
+          x2={tick2.x - pux2 * tickLen} y2={tick2.y - puy2 * tickLen}
           stroke="#0369A1" strokeWidth={2.5} strokeLinecap="round"
         />
         {/* Direction arrow at the receiver end */}
@@ -555,6 +646,7 @@ export default function AnnotationLayer({
   const setSelectedAnnotationId = useStore((s) => s.setSelectedAnnotationId);
   const addAnnotation = useStore((s) => s.addAnnotation);
   const removeAnnotation = useStore((s) => s.removeAnnotation);
+  const updateAnnotation = useStore((s) => s.updateAnnotation);
   const isPlaying = useStore((s) => s.isPlaying);
   const currentStep = useStore((s) => s.currentStep);
   const scene = useStore(selectEditorScene);
@@ -582,6 +674,13 @@ export default function AnnotationLayer({
   // In-progress stroke state
   const [drawing, setDrawing] = useState<{ from: Point; to: Point } | null>(null);
   const drawingRef = useRef<{ from: Point; to: Point } | null>(null);
+
+  // Control-point dragging state (for bending existing annotations)
+  const cpDragRef = useRef<{
+    annotationId: string;
+    annotation: Annotation;
+  } | null>(null);
+  const [cpDragging, setCpDragging] = useState(false);
 
   // Snap highlight — player near cursor
   const [snapTarget, setSnapTarget] = useState<SnapPlayer | null>(null);
@@ -639,10 +738,25 @@ export default function AnnotationLayer({
     [isDrawingTool, selectedTool, getSVGCoords, players, defenseOnly],
   );
 
-  // Mouse move — update preview
+  // Mouse move — update preview or drag control point
   const handleMouseMove = useCallback(
     (e: React.MouseEvent<SVGSVGElement>) => {
       const pt = getSVGCoords(e);
+
+      // If dragging a control point, update the annotation
+      if (cpDragRef.current && sceneId) {
+        const { annotation } = cpDragRef.current;
+        const cpNorm = {
+          x: (pt.x - offsetX) / paWidth,
+          y: flipped ? 1 - (pt.y - offsetY) / paHeight : (pt.y - offsetY) / paHeight,
+        };
+        const updated = { ...annotation, controlPoints: [cpNorm] };
+        // Keep the ref's annotation up-to-date so consecutive moves see the latest CP
+        cpDragRef.current.annotation = updated;
+        updateAnnotation(sceneId, updated);
+        return;
+      }
+
       // While dragging a guard annotation, snap the endpoint to offense only.
       const snapPool =
         selectedTool === "guard" && drawingRef.current
@@ -657,12 +771,19 @@ export default function AnnotationLayer({
       drawingRef.current = next;
       setDrawing(next);
     },
-    [getSVGCoords, players, offenseOnly, selectedTool],
+    [getSVGCoords, players, offenseOnly, selectedTool, sceneId, updateAnnotation, paWidth, paHeight, offsetX, offsetY, flipped],
   );
 
-  // Mouse up — commit annotation
+  // Mouse up — commit annotation or finish CP drag
   const handleMouseUp = useCallback(
     (e: React.MouseEvent<SVGSVGElement>) => {
+      // Finish control-point drag
+      if (cpDragRef.current) {
+        cpDragRef.current = null;
+        setCpDragging(false);
+        return;
+      }
+
       if (!drawingRef.current || !sceneId) {
         setDrawing(null);
         drawingRef.current = null;
@@ -727,6 +848,27 @@ export default function AnnotationLayer({
     ],
   );
 
+  // Mouse down on a control-point drag handle
+  const handleCpMouseDown = useCallback(
+    (e: React.MouseEvent, ann: Annotation) => {
+      e.stopPropagation();
+      e.preventDefault();
+      if (!sceneId) return;
+      // Push undo snapshot before the drag begins
+      const state = useStore.getState();
+      const { currentPlay, selectedSceneId: sid } = state;
+      if (currentPlay) {
+        useHistoryStore.getState().pushSnapshot({
+          play: JSON.parse(JSON.stringify(currentPlay)) as typeof currentPlay,
+          selectedSceneId: sid,
+        });
+      }
+      cpDragRef.current = { annotationId: ann.id, annotation: ann };
+      setCpDragging(true);
+    },
+    [sceneId],
+  );
+
   // Handle eraser click on annotation
   const handleAnnotationSelect = useCallback(
     (id: string) => {
@@ -739,7 +881,34 @@ export default function AnnotationLayer({
     [selectedTool, sceneId, removeAnnotation, setSelectedAnnotationId],
   );
 
-  const cursor = TOOL_CURSOR[selectedTool];
+  const cursor = cpDragging ? "grabbing" : TOOL_CURSOR[selectedTool];
+
+  // Find the selected annotation for control-point handle rendering
+  const selectedAnnotation = selectedAnnotationId
+    ? annotations.find((a) => a.id === selectedAnnotationId) ?? null
+    : null;
+
+  // Compute SVG-pixel coords for the selected annotation's control point handle.
+  // The handle is shown only in "select" mode and only when the screen is not animating.
+  const showCpHandle = !isPlaying && selectedTool === "select" && selectedAnnotation !== null;
+
+  const normToSvgForHandle = (nx: number, ny: number) => ({
+    x: nx * paWidth + offsetX,
+    y: flipped ? (1 - ny) * paHeight + offsetY : ny * paHeight + offsetY,
+  });
+
+  let cpHandlePx: Point | null = null;
+  if (showCpHandle && selectedAnnotation) {
+    const annFrom = normToSvgForHandle(selectedAnnotation.from.x, selectedAnnotation.from.y);
+    const annTo   = normToSvgForHandle(selectedAnnotation.to.x,   selectedAnnotation.to.y);
+    if (selectedAnnotation.controlPoints.length > 0) {
+      const cpNorm = selectedAnnotation.controlPoints[0];
+      cpHandlePx = normToSvgForHandle(cpNorm.x, cpNorm.y);
+    } else {
+      // Default handle position: midpoint of the straight line (user hasn't curved it yet)
+      cpHandlePx = defaultControlPoint(annFrom, annTo);
+    }
+  }
 
   return (
     <svg
@@ -752,8 +921,9 @@ export default function AnnotationLayer({
         height,
         overflow: "visible",
         cursor,
-        // Only capture events when a drawing tool is active
-        pointerEvents: isDrawingTool ? "all" : "none",
+        // Capture events when drawing, when dragging a control point, or when
+        // in select mode with an annotation selected (so the CP handle is clickable).
+        pointerEvents: (isDrawingTool || cpDragging || showCpHandle) ? "all" : "none",
       }}
       viewBox={`0 0 ${width} ${height}`}
       aria-label="Annotation drawing layer"
@@ -778,6 +948,48 @@ export default function AnnotationLayer({
           flipped={flipped}
         />
       ))}
+
+      {/* Control-point drag handle for selected annotation */}
+      {showCpHandle && cpHandlePx && selectedAnnotation && (
+        <g>
+          {/* Dotted guide line from annotation midpoint area to the handle */}
+          {selectedAnnotation.controlPoints.length > 0 && (() => {
+            const annFrom = normToSvgForHandle(selectedAnnotation.from.x, selectedAnnotation.from.y);
+            const annTo   = normToSvgForHandle(selectedAnnotation.to.x,   selectedAnnotation.to.y);
+            const mid = defaultControlPoint(annFrom, annTo);
+            return (
+              <line
+                x1={mid.x} y1={mid.y}
+                x2={cpHandlePx!.x} y2={cpHandlePx!.y}
+                stroke="#3B82F6"
+                strokeWidth={1}
+                strokeDasharray="3 3"
+                pointerEvents="none"
+                opacity={0.5}
+              />
+            );
+          })()}
+          {/* Outer ring */}
+          <circle
+            cx={cpHandlePx.x}
+            cy={cpHandlePx.y}
+            r={10}
+            fill="white"
+            stroke="#3B82F6"
+            strokeWidth={1.5}
+            style={{ cursor: "grab", pointerEvents: "all" }}
+            onMouseDown={(e) => handleCpMouseDown(e, selectedAnnotation)}
+          />
+          {/* Inner dot */}
+          <circle
+            cx={cpHandlePx.x}
+            cy={cpHandlePx.y}
+            r={4}
+            fill="#3B82F6"
+            pointerEvents="none"
+          />
+        </g>
+      )}
 
       {/* Snap target ring */}
       {snapTarget && isDrawingTool && (

--- a/src/lib/exportPNG.ts
+++ b/src/lib/exportPNG.ts
@@ -363,153 +363,206 @@ function drawArrowHead(
   ctx.fill();
 }
 
+/** Quadratic bezier point at parameter t. */
+function bezierPointPNG(
+  fx: number, fy: number,
+  tx: number, ty: number,
+  t: number,
+  cpx?: number, cpy?: number,
+): { x: number; y: number } {
+  if (cpx === undefined || cpy === undefined) {
+    return { x: fx + (tx - fx) * t, y: fy + (ty - fy) * t };
+  }
+  const mt = 1 - t;
+  return {
+    x: mt * mt * fx + 2 * mt * t * cpx + t * t * tx,
+    y: mt * mt * fy + 2 * mt * t * cpy + t * t * ty,
+  };
+}
+
+/** Draw a bezier or straight line body. Uses quadraticCurveTo when control point given. */
+function drawBezierBody(
+  ctx: CanvasRenderingContext2D,
+  fx: number, fy: number,
+  tx: number, ty: number,
+  cpx?: number, cpy?: number,
+): void {
+  ctx.beginPath();
+  ctx.moveTo(fx, fy);
+  if (cpx !== undefined && cpy !== undefined) {
+    ctx.quadraticCurveTo(cpx, cpy, tx, ty);
+  } else {
+    ctx.lineTo(tx, ty);
+  }
+  ctx.stroke();
+}
+
+/** Arrowhead at (tx, ty) directed from last control point or from (fx, fy). */
+function drawArrowHeadBezier(
+  ctx: CanvasRenderingContext2D,
+  fx: number, fy: number,
+  tx: number, ty: number,
+  size: number,
+  color: string,
+  cpx?: number, cpy?: number,
+): void {
+  // Tangent at t=1: from cp (or from) to to
+  const tailX = cpx !== undefined ? cpx : fx;
+  const tailY = cpy !== undefined ? cpy : fy;
+  drawArrowHead(ctx, tailX, tailY, tx, ty, size, color);
+}
+
 function drawAnnotation(
   ctx: CanvasRenderingContext2D,
   ann: Annotation,
   scale: number,
+  width: number,
+  height: number,
 ) {
-  const { from, to, type } = ann;
+  // Convert normalised [0-1] coords to CSS pixel space
+  const fx = ann.from.x * width;
+  const fy = ann.from.y * height;
+  const tx = ann.to.x   * width;
+  const ty = ann.to.y   * height;
+
+  // Bezier control point (if any)
+  let cpx: number | undefined;
+  let cpy: number | undefined;
+  if (ann.controlPoints.length > 0) {
+    cpx = ann.controlPoints[0].x * width;
+    cpy = ann.controlPoints[0].y * height;
+  }
+
   const arrowSize = 12 * scale;
 
   ctx.lineCap = "round";
   ctx.lineJoin = "round";
 
-  if (type === "movement") {
-    ctx.beginPath();
-    ctx.moveTo(from.x, from.y);
-    ctx.lineTo(to.x, to.y);
+  if (ann.type === "movement") {
     ctx.strokeStyle = "#1E3A5F";
     ctx.lineWidth = 2.5 * scale;
-    ctx.stroke();
-    drawArrowHead(ctx, from.x, from.y, to.x, to.y, arrowSize, "#1E3A5F");
+    drawBezierBody(ctx, fx, fy, tx, ty, cpx, cpy);
+    drawArrowHeadBezier(ctx, fx, fy, tx, ty, arrowSize, "#1E3A5F", cpx, cpy);
     return;
   }
 
-  if (type === "dribble") {
-    const dx = to.x - from.x;
-    const dy = to.y - from.y;
-    const len = Math.sqrt(dx * dx + dy * dy);
-    const zigCount = Math.max(2, Math.round(len / (18 * scale)));
-    ctx.beginPath();
-    for (let i = 0; i <= zigCount; i++) {
-      const t = i / zigCount;
-      const mx = from.x + dx * t;
-      const my = from.y + dy * t;
-      const perp = i % 2 === 0 ? 6 * scale : -6 * scale;
-      const px2 = len > 0 ? (-dy / len) * perp : 0;
-      const py2 = len > 0 ? (dx / len) * perp : 0;
-      if (i === 0) ctx.moveTo(mx + px2, my + py2);
-      else ctx.lineTo(mx + px2, my + py2);
+  if (ann.type === "dribble") {
+    ctx.strokeStyle = "#1E3A5F";
+    ctx.lineWidth = 2.5 * scale;
+    if (cpx !== undefined && cpy !== undefined) {
+      // Curved dribble: dashed bezier path
+      ctx.setLineDash([5 * scale, 4 * scale]);
+      drawBezierBody(ctx, fx, fy, tx, ty, cpx, cpy);
+      ctx.setLineDash([]);
+      drawArrowHeadBezier(ctx, fx, fy, tx, ty, arrowSize, "#1E3A5F", cpx, cpy);
+    } else {
+      // Straight zigzag
+      const dx = tx - fx;
+      const dy = ty - fy;
+      const len = Math.sqrt(dx * dx + dy * dy);
+      const zigCount = Math.max(2, Math.round(len / (18 * scale)));
+      ctx.beginPath();
+      for (let i = 0; i <= zigCount; i++) {
+        const t = i / zigCount;
+        const mx = fx + dx * t;
+        const my = fy + dy * t;
+        const perp = i % 2 === 0 ? 6 * scale : -6 * scale;
+        const px2 = len > 0 ? (-dy / len) * perp : 0;
+        const py2 = len > 0 ? (dx / len) * perp : 0;
+        if (i === 0) ctx.moveTo(mx + px2, my + py2);
+        else ctx.lineTo(mx + px2, my + py2);
+      }
+      ctx.stroke();
+      drawArrowHead(ctx, fx, fy, tx, ty, arrowSize, "#1E3A5F");
     }
-    ctx.strokeStyle = "#1E3A5F";
-    ctx.lineWidth = 2.5 * scale;
-    ctx.stroke();
-    drawArrowHead(ctx, from.x, from.y, to.x, to.y, arrowSize, "#1E3A5F");
     return;
   }
 
-  if (type === "pass") {
-    ctx.beginPath();
-    ctx.moveTo(from.x, from.y);
-    ctx.lineTo(to.x, to.y);
+  if (ann.type === "pass") {
     ctx.strokeStyle = "#059669";
     ctx.lineWidth = 2 * scale;
-    ctx.stroke();
-    drawArrowHead(ctx, from.x, from.y, to.x, to.y, arrowSize, "#059669");
+    drawBezierBody(ctx, fx, fy, tx, ty, cpx, cpy);
+    drawArrowHeadBezier(ctx, fx, fy, tx, ty, arrowSize, "#059669", cpx, cpy);
     return;
   }
 
-  if (type === "screen") {
-    const dx = to.x - from.x;
-    const dy = to.y - from.y;
+  if (ann.type === "screen") {
+    const dx = tx - fx;
+    const dy = ty - fy;
     const len = Math.sqrt(dx * dx + dy * dy);
     const perpX = len > 0 ? (-dy / len) * 10 * scale : 0;
     const perpY = len > 0 ? (dx / len) * 10 * scale : 0;
-    ctx.beginPath();
-    ctx.moveTo(from.x, from.y);
-    ctx.lineTo(to.x, to.y);
     ctx.strokeStyle = "#7C3AED";
     ctx.lineWidth = 2.5 * scale;
-    ctx.stroke();
+    drawBezierBody(ctx, fx, fy, tx, ty, cpx, cpy);
     // Perpendicular bar
     ctx.beginPath();
-    ctx.moveTo(to.x + perpX, to.y + perpY);
-    ctx.lineTo(to.x - perpX, to.y - perpY);
+    ctx.moveTo(tx + perpX, ty + perpY);
+    ctx.lineTo(tx - perpX, ty - perpY);
     ctx.lineWidth = 3 * scale;
     ctx.stroke();
     return;
   }
 
-  if (type === "cut") {
-    ctx.beginPath();
-    ctx.moveTo(from.x, from.y);
-    ctx.lineTo(to.x, to.y);
+  if (ann.type === "cut") {
     ctx.strokeStyle = "#DC2626";
     ctx.lineWidth = 2.5 * scale;
     ctx.setLineDash([7 * scale, 5 * scale]);
-    ctx.stroke();
+    drawBezierBody(ctx, fx, fy, tx, ty, cpx, cpy);
     ctx.setLineDash([]);
-    drawArrowHead(ctx, from.x, from.y, to.x, to.y, arrowSize, "#DC2626");
+    drawArrowHeadBezier(ctx, fx, fy, tx, ty, arrowSize, "#DC2626", cpx, cpy);
     return;
   }
 
-  if (type === "guard") {
-    ctx.beginPath();
-    ctx.moveTo(from.x, from.y);
-    ctx.lineTo(to.x, to.y);
+  if (ann.type === "guard") {
     ctx.strokeStyle = "#D97706";
     ctx.lineWidth = 2 * scale;
     ctx.globalAlpha = 0.85;
     ctx.setLineDash([4 * scale, 4 * scale]);
-    ctx.stroke();
+    drawBezierBody(ctx, fx, fy, tx, ty, cpx, cpy);
     ctx.setLineDash([]);
     ctx.globalAlpha = 1;
     return;
   }
 
-  if (type === "handoff") {
-    const dx = to.x - from.x;
-    const dy = to.y - from.y;
-    const len = Math.sqrt(dx * dx + dy * dy);
-    const ux = len > 0 ? dx / len : 1;
-    const uy = len > 0 ? dy / len : 0;
-    // Perpendicular direction
-    const px2 = -uy;
-    const py2 = ux;
-    const tickLen = 9 * scale;
-    // Tick positions along the line
-    const t1 = 0.85;
-    const t1x = from.x + dx * t1;
-    const t1y = from.y + dy * t1;
-    const t2 = 0.72;
-    const t2x = from.x + dx * t2;
-    const t2y = from.y + dy * t2;
-
+  if (ann.type === "handoff") {
     ctx.strokeStyle = "#0369A1";
     ctx.lineWidth = 2.5 * scale;
     ctx.lineCap = "round";
 
-    // Dashed body line
+    // Dashed body line (bezier-aware)
     ctx.setLineDash([6 * scale, 4 * scale]);
-    ctx.beginPath();
-    ctx.moveTo(from.x, from.y);
-    ctx.lineTo(to.x, to.y);
-    ctx.stroke();
+    drawBezierBody(ctx, fx, fy, tx, ty, cpx, cpy);
     ctx.setLineDash([]);
 
-    // Tick marks
+    // Tick marks at t=0.85 and t=0.72 (bezier-aware)
+    const tick1 = bezierPointPNG(fx, fy, tx, ty, 0.85, cpx, cpy);
+    const tick2 = bezierPointPNG(fx, fy, tx, ty, 0.72, cpx, cpy);
+    // Perpendicular using tangent at those points
+    const tan1Before = bezierPointPNG(fx, fy, tx, ty, 0.83, cpx, cpy);
+    const tan2Before = bezierPointPNG(fx, fy, tx, ty, 0.70, cpx, cpy);
+    const getPerp = (pt: { x: number; y: number }, before: { x: number; y: number }) => {
+      const ddx = pt.x - before.x;
+      const ddy = pt.y - before.y;
+      const dlen = Math.sqrt(ddx * ddx + ddy * ddy);
+      return { px: dlen > 0 ? -ddy / dlen : 0, py: dlen > 0 ? ddx / dlen : 1 };
+    };
+    const tickLen = 9 * scale;
+    const { px: px1, py: py1 } = getPerp(tick1, tan1Before);
+    const { px: px2, py: py2 } = getPerp(tick2, tan2Before);
+
     ctx.beginPath();
-    ctx.moveTo(t1x + px2 * tickLen, t1y + py2 * tickLen);
-    ctx.lineTo(t1x - px2 * tickLen, t1y - py2 * tickLen);
+    ctx.moveTo(tick1.x + px1 * tickLen, tick1.y + py1 * tickLen);
+    ctx.lineTo(tick1.x - px1 * tickLen, tick1.y - py1 * tickLen);
     ctx.stroke();
 
     ctx.beginPath();
-    ctx.moveTo(t2x + px2 * tickLen, t2y + py2 * tickLen);
-    ctx.lineTo(t2x - px2 * tickLen, t2y - py2 * tickLen);
+    ctx.moveTo(tick2.x + px2 * tickLen, tick2.y + py2 * tickLen);
+    ctx.lineTo(tick2.x - px2 * tickLen, tick2.y - py2 * tickLen);
     ctx.stroke();
 
-    // Arrowhead
-    drawArrowHead(ctx, from.x, from.y, to.x, to.y, arrowSize, "#0369A1");
+    // Arrowhead at receiver end
+    drawArrowHeadBezier(ctx, fx, fy, tx, ty, arrowSize, "#0369A1", cpx, cpy);
   }
 }
 
@@ -582,7 +635,7 @@ function drawOverlay(
   // Draw all annotations first (below players)
   const annotations = scene.timingGroups.flatMap((g) => g.annotations);
   for (const ann of annotations) {
-    drawAnnotation(ctx, ann, scale);
+    drawAnnotation(ctx, ann, scale, width, height);
   }
 
   // Defensive players (below offensive)

--- a/src/lib/exportPdf.ts
+++ b/src/lib/exportPdf.ts
@@ -166,6 +166,53 @@ function drawArrowHead(
   ctx.fill();
 }
 
+/** Quadratic bezier point at parameter t. */
+function bezierPt(
+  fx: number, fy: number,
+  tx: number, ty: number,
+  t: number,
+  cpx?: number, cpy?: number,
+): { x: number; y: number } {
+  if (cpx === undefined || cpy === undefined) {
+    return { x: fx + (tx - fx) * t, y: fy + (ty - fy) * t };
+  }
+  const mt = 1 - t;
+  return {
+    x: mt * mt * fx + 2 * mt * t * cpx + t * t * tx,
+    y: mt * mt * fy + 2 * mt * t * cpy + t * t * ty,
+  };
+}
+
+/** Draw quadratic bezier or straight-line body. */
+function strokeBezier(
+  ctx: CanvasRenderingContext2D,
+  fx: number, fy: number,
+  tx: number, ty: number,
+  cpx?: number, cpy?: number,
+): void {
+  ctx.beginPath();
+  ctx.moveTo(fx, fy);
+  if (cpx !== undefined && cpy !== undefined) {
+    ctx.quadraticCurveTo(cpx, cpy, tx, ty);
+  } else {
+    ctx.lineTo(tx, ty);
+  }
+  ctx.stroke();
+}
+
+/** Arrowhead at (tx, ty) using bezier tangent direction. */
+function arrowHeadBezierPdf(
+  ctx: CanvasRenderingContext2D,
+  fx: number, fy: number,
+  tx: number, ty: number,
+  size: number,
+  cpx?: number, cpy?: number,
+): void {
+  const tailX = cpx !== undefined ? cpx : fx;
+  const tailY = cpy !== undefined ? cpy : fy;
+  drawArrowHead(ctx, tx, ty, tailX, tailY, size);
+}
+
 function drawAnnotation(
   ctx: CanvasRenderingContext2D,
   ann: Annotation,
@@ -178,6 +225,14 @@ function drawAnnotation(
   const tx = ann.to.x * canvasW;
   const ty = ann.to.y * canvasH;
 
+  // Bezier control point (if any)
+  let cpx: number | undefined;
+  let cpy: number | undefined;
+  if (ann.controlPoints.length > 0) {
+    cpx = ann.controlPoints[0].x * canvasW;
+    cpy = ann.controlPoints[0].y * canvasH;
+  }
+
   const color = ANN_COLOR[ann.type] ?? "#1E3A5F";
 
   ctx.save();
@@ -189,38 +244,41 @@ function drawAnnotation(
 
   if (ann.type === "movement" || ann.type === "pass") {
     ctx.setLineDash([]);
-    ctx.beginPath();
-    ctx.moveTo(fx, fy);
-    ctx.lineTo(tx, ty);
-    ctx.stroke();
-    drawArrowHead(ctx, tx, ty, fx, fy, ANN_ARROW_SIZE);
+    strokeBezier(ctx, fx, fy, tx, ty, cpx, cpy);
+    arrowHeadBezierPdf(ctx, fx, fy, tx, ty, ANN_ARROW_SIZE, cpx, cpy);
 
   } else if (ann.type === "dribble") {
-    const dx = tx - fx;
-    const dy = ty - fy;
-    const len = Math.sqrt(dx * dx + dy * dy);
-    const zigCount = Math.max(2, Math.round(len / DRIBBLE_SEGMENT));
-    ctx.setLineDash([]);
-    ctx.beginPath();
-    for (let i = 0; i <= zigCount; i++) {
-      const t = i / zigCount;
-      const mx = fx + dx * t;
-      const my = fy + dy * t;
-      const perp = i % 2 === 0 ? DRIBBLE_PERP : -DRIBBLE_PERP;
-      const px2 = len > 0 ? -dy / len * perp : 0;
-      const py2 = len > 0 ? dx / len * perp : 0;
-      if (i === 0) ctx.moveTo(mx + px2, my + py2);
-      else ctx.lineTo(mx + px2, my + py2);
+    if (cpx !== undefined && cpy !== undefined) {
+      // Curved dribble: dashed bezier
+      ctx.setLineDash([ANN_LINE_W * 3, ANN_LINE_W * 2]);
+      strokeBezier(ctx, fx, fy, tx, ty, cpx, cpy);
+      ctx.setLineDash([]);
+      arrowHeadBezierPdf(ctx, fx, fy, tx, ty, ANN_ARROW_SIZE, cpx, cpy);
+    } else {
+      // Straight zigzag
+      const dx = tx - fx;
+      const dy = ty - fy;
+      const len = Math.sqrt(dx * dx + dy * dy);
+      const zigCount = Math.max(2, Math.round(len / DRIBBLE_SEGMENT));
+      ctx.setLineDash([]);
+      ctx.beginPath();
+      for (let i = 0; i <= zigCount; i++) {
+        const t = i / zigCount;
+        const mx = fx + dx * t;
+        const my = fy + dy * t;
+        const perp = i % 2 === 0 ? DRIBBLE_PERP : -DRIBBLE_PERP;
+        const px2 = len > 0 ? -dy / len * perp : 0;
+        const py2 = len > 0 ? dx / len * perp : 0;
+        if (i === 0) ctx.moveTo(mx + px2, my + py2);
+        else ctx.lineTo(mx + px2, my + py2);
+      }
+      ctx.stroke();
+      drawArrowHead(ctx, tx, ty, fx, fy, ANN_ARROW_SIZE);
     }
-    ctx.stroke();
-    drawArrowHead(ctx, tx, ty, fx, fy, ANN_ARROW_SIZE);
 
   } else if (ann.type === "screen") {
     ctx.setLineDash([]);
-    ctx.beginPath();
-    ctx.moveTo(fx, fy);
-    ctx.lineTo(tx, ty);
-    ctx.stroke();
+    strokeBezier(ctx, fx, fy, tx, ty, cpx, cpy);
 
     // Perpendicular bar at the end
     const dx = tx - fx;
@@ -237,58 +295,48 @@ function drawAnnotation(
 
   } else if (ann.type === "cut") {
     ctx.setLineDash([ANN_LINE_W * 4, ANN_LINE_W * 3]);
-    ctx.beginPath();
-    ctx.moveTo(fx, fy);
-    ctx.lineTo(tx, ty);
-    ctx.stroke();
+    strokeBezier(ctx, fx, fy, tx, ty, cpx, cpy);
     ctx.setLineDash([]);
-    drawArrowHead(ctx, tx, ty, fx, fy, ANN_ARROW_SIZE);
+    arrowHeadBezierPdf(ctx, fx, fy, tx, ty, ANN_ARROW_SIZE, cpx, cpy);
 
   } else if (ann.type === "guard") {
     ctx.globalAlpha = 0.85;
     ctx.setLineDash([ANN_LINE_W * 4, ANN_LINE_W * 4]);
-    ctx.beginPath();
-    ctx.moveTo(fx, fy);
-    ctx.lineTo(tx, ty);
-    ctx.stroke();
+    strokeBezier(ctx, fx, fy, tx, ty, cpx, cpy);
     ctx.setLineDash([]);
     ctx.globalAlpha = 1;
 
   } else if (ann.type === "handoff") {
-    const dx = tx - fx;
-    const dy = ty - fy;
-    const len = Math.sqrt(dx * dx + dy * dy);
-    const ux = len > 0 ? dx / len : 1;
-    const uy = len > 0 ? dy / len : 0;
-    const px2 = -uy;
-    const py2 = ux;
-    const tickLen = ANN_ARROW_SIZE * 0.75;
-    const t1 = 0.85;
-    const t1x = fx + dx * t1;
-    const t1y = fy + dy * t1;
-    const t2 = 0.72;
-    const t2x = fx + dx * t2;
-    const t2y = fy + dy * t2;
-
     ctx.setLineDash([ANN_LINE_W * 3, ANN_LINE_W * 2]);
-    ctx.beginPath();
-    ctx.moveTo(fx, fy);
-    ctx.lineTo(tx, ty);
-    ctx.stroke();
+    strokeBezier(ctx, fx, fy, tx, ty, cpx, cpy);
     ctx.setLineDash([]);
 
-    // Tick marks
+    // Tick marks at t=0.85 and t=0.72 (bezier-aware)
+    const tick1 = bezierPt(fx, fy, tx, ty, 0.85, cpx, cpy);
+    const tick2 = bezierPt(fx, fy, tx, ty, 0.72, cpx, cpy);
+    const tan1Before = bezierPt(fx, fy, tx, ty, 0.83, cpx, cpy);
+    const tan2Before = bezierPt(fx, fy, tx, ty, 0.70, cpx, cpy);
+    const getPerp = (pt: { x: number; y: number }, before: { x: number; y: number }) => {
+      const ddx = pt.x - before.x;
+      const ddy = pt.y - before.y;
+      const dlen = Math.sqrt(ddx * ddx + ddy * ddy);
+      return { px: dlen > 0 ? -ddy / dlen : 0, py: dlen > 0 ? ddx / dlen : 1 };
+    };
+    const tickLen = ANN_ARROW_SIZE * 0.75;
+    const { px: px1, py: py1 } = getPerp(tick1, tan1Before);
+    const { px: px2, py: py2 } = getPerp(tick2, tan2Before);
+
     ctx.beginPath();
-    ctx.moveTo(t1x + px2 * tickLen, t1y + py2 * tickLen);
-    ctx.lineTo(t1x - px2 * tickLen, t1y - py2 * tickLen);
+    ctx.moveTo(tick1.x + px1 * tickLen, tick1.y + py1 * tickLen);
+    ctx.lineTo(tick1.x - px1 * tickLen, tick1.y - py1 * tickLen);
     ctx.stroke();
 
     ctx.beginPath();
-    ctx.moveTo(t2x + px2 * tickLen, t2y + py2 * tickLen);
-    ctx.lineTo(t2x - px2 * tickLen, t2y - py2 * tickLen);
+    ctx.moveTo(tick2.x + px2 * tickLen, tick2.y + py2 * tickLen);
+    ctx.lineTo(tick2.x - px2 * tickLen, tick2.y - py2 * tickLen);
     ctx.stroke();
 
-    drawArrowHead(ctx, tx, ty, fx, fy, ANN_ARROW_SIZE);
+    arrowHeadBezierPdf(ctx, fx, fy, tx, ty, ANN_ARROW_SIZE, cpx, cpy);
   }
 
   ctx.setLineDash([]);

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -88,6 +88,7 @@ export interface AppStore {
   // Timing group / annotation mutations
   addAnnotation: (sceneId: string, timingStep: number, annotation: Annotation) => void;
   removeAnnotation: (sceneId: string, annotationId: string) => void;
+  updateAnnotation: (sceneId: string, annotation: Annotation) => void;
   moveAnnotationToStep: (sceneId: string, annotationId: string, newStep: number) => void;
   addTimingStep: (sceneId: string) => void;
   removeTimingStep: (sceneId: string, step: number) => void;
@@ -611,6 +612,26 @@ export const useStore = create<AppStore>()(
           })),
           selectedAnnotationId:
             currentSelectedAnnotation === annotationId ? null : currentSelectedAnnotation,
+        };
+      });
+    },
+
+    updateAnnotation: (sceneId, annotation) => {
+      // NOTE: Control point drag does not push to undo history to avoid flooding
+      // the history stack on every mouse-move event. History is captured on mousedown
+      // (before the drag) in AnnotationLayer.
+      set((s) => {
+        if (!s.currentPlay) return s;
+        return {
+          currentPlay: withUpdatedScene(s.currentPlay, sceneId, (sc) => ({
+            ...sc,
+            timingGroups: sc.timingGroups.map((g) => ({
+              ...g,
+              annotations: g.annotations.map((a) =>
+                a.id === annotation.id ? annotation : a,
+              ),
+            })),
+          })),
         };
       });
     },


### PR DESCRIPTION
## Summary

Resolves #142 — Curved annotation lines (bezier arcs).

- **Control-point drag handle**: When an annotation is selected in select mode, a blue ring handle appears at the midpoint. Dragging it bends the line into a quadratic bezier curve.
- **All annotation types** support curves: movement, pass, cut, guard, dribble (curved uses dashed path), handoff (tick marks follow bezier tangent).
- **Backwards compatible**: annotations with empty `controlPoints` render as straight lines (no change to existing data).
- **Undo support**: a snapshot is pushed to history before each drag begins; the live-drag updates do not flood the undo stack.
- **Export rendering** (PNG + PDF): both exports now render bezier curves via `quadraticCurveTo`. As a side-effect, the PNG export also gets a coordinate-system fix — annotations were previously drawn at normalized `[0-1]` pixel positions instead of scaled pixel coordinates.

## Implementation details

| File | Change |
|---|---|
| `src/lib/store.ts` | Added `updateAnnotation(sceneId, annotation)` — updates annotation in-place without pushing undo snapshot |
| `src/components/annotations/AnnotationLayer.tsx` | bezier helpers (`bezierPath`, `bezierPoint`, `arrowHeadBezier`); all rendered types use `<path d="M … Q cp to">` when `controlPoints[0]` present; CP drag handle rendered for selected annotation in select mode |
| `src/lib/exportPNG.ts` | `drawAnnotation` now takes `width`/`height` to convert normalised → pixel coords; uses `quadraticCurveTo` for curved annotations |
| `src/lib/exportPdf.ts` | `drawAnnotation` uses `quadraticCurveTo` for curved annotations; tick marks on handoff follow bezier tangent |

## Test plan

- [ ] Draw a movement annotation, switch to select tool, select the annotation — a blue handle appears at its midpoint
- [ ] Drag the handle — the line bends into a smooth quadratic bezier curve
- [ ] Release mouse — curve persists; Cmd-Z undoes the curve (restores straight line)
- [ ] Verify that unmodified annotations (no control point) still render as straight lines
- [ ] Export scene as PNG — curved annotations render correctly at full size
- [ ] Export play as PDF — curved annotations render correctly

> This PR should be squash-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)