### PR TITLE
Fix #129: Multi-leg player paths within a scene

### DIFF
--- a/src/components/annotations/AnnotationLayer.tsx
+++ b/src/components/annotations/AnnotationLayer.tsx
@@ -32,6 +32,27 @@ import { TOOL_CURSOR } from "@/components/editor/DrawingToolsPanel";
 import { useHistoryStore } from "@/lib/history";
 
 // ---------------------------------------------------------------------------
+// Multi-leg path helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return all points in a (possibly multi-leg) annotation's path:
+ *   from → waypoints[0] → ... → waypoints[n-1] → to
+ * All points are in normalised [0-1] coords.
+ */
+function annPathPoints(ann: Annotation): Point[] {
+  return [ann.from, ...(ann.waypoints ?? []), ann.to];
+}
+
+/**
+ * Return true when the annotation type supports multi-leg extension.
+ * Guard / handoff are assignment-style and do not get extra legs.
+ */
+function isExtendable(type: Annotation["type"]): boolean {
+  return type === "movement" || type === "cut" || type === "dribble";
+}
+
+// ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
@@ -44,6 +65,15 @@ const SNAP_RING_RADIUS = 24;
 // ---------------------------------------------------------------------------
 // Rendering helpers per annotation type
 // ---------------------------------------------------------------------------
+
+/**
+ * Build an SVG polyline `d` string through a sequence of pixel points.
+ * Used for multi-leg paths (when waypoints are present).
+ */
+function polylinePath(pts: { x: number; y: number }[]): string {
+  if (pts.length < 2) return "";
+  return `M ${pts.map((p) => `${p.x},${p.y}`).join(" L ")}`;
+}
 
 /** Compute an arrowhead polygon points string given a line endpoint and direction. */
 function arrowHead(
@@ -162,15 +192,23 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
   const from = normToSvg(ann.from.x, ann.from.y);
   const to   = normToSvg(ann.to.x,   ann.to.y);
 
-  // Control point (bezier curve support)
-  const cp: Point | undefined = ann.controlPoints.length > 0
+  // Multi-leg path support: convert all waypoints to pixel space
+  const hasWaypoints = ann.waypoints && ann.waypoints.length > 0;
+  const allPxPoints: { x: number; y: number }[] = hasWaypoints
+    ? annPathPoints(ann).map((p) => normToSvg(p.x, p.y))
+    : [];
+
+  // Control point (bezier curve support — only for single-leg annotations)
+  const cp: Point | undefined = !hasWaypoints && ann.controlPoints.length > 0
     ? normToSvg(ann.controlPoints[0].x, ann.controlPoints[0].y)
     : undefined;
 
   const hitStyle: React.CSSProperties = { cursor: "pointer", pointerEvents: "stroke" };
 
-  // Step badge — small circle at the midpoint of the annotation (on the curve)
-  const mid = bezierPoint(from, to, 0.5, cp);
+  // Step badge — small circle at the midpoint of the path
+  const mid = hasWaypoints && allPxPoints.length >= 2
+    ? allPxPoints[Math.floor(allPxPoints.length / 2)]
+    : bezierPoint(from, to, 0.5, cp);
   const midX = mid.x;
   const midY = mid.y;
   const stepBadge = showStepBadge && step !== undefined ? (
@@ -190,17 +228,29 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
     </g>
   ) : null;
 
+  // For multi-leg: arrowhead from second-to-last to last point
   // For straight lines use legacy arrowHead; for bezier use bezier tangent
-  const headPoints = cp
+  const headPoints = hasWaypoints && allPxPoints.length >= 2
+    ? arrowHead(allPxPoints[allPxPoints.length - 1].x, allPxPoints[allPxPoints.length - 1].y,
+                allPxPoints[allPxPoints.length - 2].x, allPxPoints[allPxPoints.length - 2].y)
+    : cp
     ? arrowHeadBezier(to, from, cp)
     : arrowHead(to.x, to.y, from.x, from.y);
 
+  // Selection ring bounding box over all path points
+  const allXs = hasWaypoints ? allPxPoints.map((p) => p.x) : [from.x, to.x];
+  const allYs = hasWaypoints ? allPxPoints.map((p) => p.y) : [from.y, to.y];
+  const minX = Math.min(...allXs);
+  const minY = Math.min(...allYs);
+  const maxX = Math.max(...allXs);
+  const maxY = Math.max(...allYs);
+
   const selectRing = selected ? (
     <rect
-      x={Math.min(from.x, to.x) - 6}
-      y={Math.min(from.y, to.y) - 6}
-      width={Math.abs(to.x - from.x) + 12}
-      height={Math.abs(to.y - from.y) + 12}
+      x={minX - 6}
+      y={minY - 6}
+      width={maxX - minX + 12}
+      height={maxY - minY + 12}
       rx={4}
       fill="none"
       stroke="#3B82F6"
@@ -216,7 +266,7 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
   };
 
   if (type === "movement") {
-    const d = bezierPath(from, to, cp);
+    const d = hasWaypoints ? polylinePath(allPxPoints) : bezierPath(from, to, cp);
     return (
       <g onClick={handleClick} style={hitStyle}>
         {selectRing}
@@ -227,6 +277,7 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
           stroke="#1E3A5F"
           strokeWidth={2.5}
           strokeLinecap="round"
+          strokeLinejoin="round"
           fill="none"
         />
         {headPoints && (
@@ -238,6 +289,27 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
   }
 
   if (type === "dribble") {
+    if (hasWaypoints) {
+      // Multi-leg dribble: render as dashed polyline (no zigzag for multi-leg)
+      const d = polylinePath(allPxPoints);
+      return (
+        <g onClick={handleClick} style={hitStyle}>
+          {selectRing}
+          <path d={d} stroke="transparent" strokeWidth={14} fill="none" />
+          <path
+            d={d}
+            stroke="#1E3A5F"
+            strokeWidth={2.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeDasharray="5 4"
+            fill="none"
+          />
+          {headPoints && <polygon points={headPoints} fill="#1E3A5F" />}
+          {stepBadge}
+        </g>
+      );
+    }
     if (cp) {
       // Curved dribble: render as bezier path (smooth) + arrowhead
       const d = bezierPath(from, to, cp);
@@ -342,7 +414,7 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
   }
 
   if (type === "cut") {
-    const d = bezierPath(from, to, cp);
+    const d = hasWaypoints ? polylinePath(allPxPoints) : bezierPath(from, to, cp);
     return (
       <g onClick={handleClick} style={hitStyle}>
         {selectRing}
@@ -352,6 +424,7 @@ function RenderedAnnotation({ ann, selected, onSelect, step, showStepBadge, widt
           stroke="#DC2626"
           strokeWidth={2.5}
           strokeLinecap="round"
+          strokeLinejoin="round"
           strokeDasharray="7 5"
           fill="none"
         />
@@ -647,6 +720,7 @@ export default function AnnotationLayer({
   const addAnnotation = useStore((s) => s.addAnnotation);
   const removeAnnotation = useStore((s) => s.removeAnnotation);
   const updateAnnotation = useStore((s) => s.updateAnnotation);
+  const appendAnnotationLeg = useStore((s) => s.appendAnnotationLeg);
   const isPlaying = useStore((s) => s.isPlaying);
   const currentStep = useStore((s) => s.currentStep);
   const scene = useStore(selectEditorScene);
@@ -675,6 +749,15 @@ export default function AnnotationLayer({
   const [drawing, setDrawing] = useState<{ from: Point; to: Point } | null>(null);
   const drawingRef = useRef<{ from: Point; to: Point } | null>(null);
 
+  // Leg-extension state: when the user starts drawing from the endpoint of an
+  // existing extendable annotation, record the annotation to extend instead of
+  // creating a new one. Cleared on mouse-up.
+  const legExtensionRef = useRef<{
+    annotationId: string;
+    /** The timing step the annotation lives in (so we don't need to look it up again). */
+    timingStep: number;
+  } | null>(null);
+
   // Control-point dragging state (for bending existing annotations)
   const cpDragRef = useRef<{
     annotationId: string;
@@ -684,6 +767,9 @@ export default function AnnotationLayer({
 
   // Snap highlight — player near cursor
   const [snapTarget, setSnapTarget] = useState<SnapPlayer | null>(null);
+
+  // Leg-extension snap highlight — annotation endpoint near cursor (when tool is extendable)
+  const [legSnapTarget, setLegSnapTarget] = useState<{ x: number; y: number } | null>(null);
 
   const isDrawingTool = selectedTool !== "select";
 
@@ -726,16 +812,49 @@ export default function AnnotationLayer({
     (e: React.MouseEvent<SVGSVGElement>) => {
       if (!isDrawingTool || selectedTool === "eraser") return;
       e.preventDefault();
+
+      legExtensionRef.current = null;
+
       const pt = getSVGCoords(e);
       const snapPool = selectedTool === "guard" ? defenseOnly : players;
       const nearest = findNearestPlayer(pt.x, pt.y, snapPool);
       const from: Point = nearest ? { x: nearest.px, y: nearest.py } : pt;
+
+      // Leg-extension detection: check if we're starting near an existing
+      // annotation's final endpoint that belongs to the same fromPlayer,
+      // and the tool matches the annotation's type.
+      if (isExtendable(selectedTool as Annotation["type"]) && scene) {
+        for (const group of scene.timingGroups) {
+          for (const ann of group.annotations) {
+            if (ann.type !== selectedTool) continue;
+            if (!isExtendable(ann.type)) continue;
+            if (!ann.fromPlayer) continue;
+            // Convert the annotation's `to` to SVG pixel space for distance check
+            const toSvgX = ann.to.x * paWidth + offsetX;
+            const toSvgY = flipped
+              ? (1 - ann.to.y) * paHeight + offsetY
+              : ann.to.y * paHeight + offsetY;
+            const dist = Math.sqrt((pt.x - toSvgX) ** 2 + (pt.y - toSvgY) ** 2);
+            if (dist <= SNAP_RADIUS) {
+              // Snap the starting point exactly to the annotation's endpoint
+              const snapFrom: Point = { x: toSvgX, y: toSvgY };
+              const stroke = { from: snapFrom, to: snapFrom };
+              setDrawing(stroke);
+              drawingRef.current = stroke;
+              setSnapTarget(null);
+              legExtensionRef.current = { annotationId: ann.id, timingStep: group.step };
+              return;
+            }
+          }
+        }
+      }
+
       const stroke = { from, to: from };
       setDrawing(stroke);
       drawingRef.current = stroke;
       setSnapTarget(null);
     },
-    [isDrawingTool, selectedTool, getSVGCoords, players, defenseOnly],
+    [isDrawingTool, selectedTool, getSVGCoords, players, defenseOnly, scene, paWidth, paHeight, offsetX, offsetY, flipped],
   );
 
   // Mouse move — update preview or drag control point
@@ -765,13 +884,35 @@ export default function AnnotationLayer({
       const nearest = findNearestPlayer(pt.x, pt.y, snapPool);
       setSnapTarget(nearest);
 
+      // Leg-extension hover: highlight annotation endpoints when not already drawing
+      if (!drawingRef.current && isExtendable(selectedTool as Annotation["type"]) && scene) {
+        let found: { x: number; y: number } | null = null;
+        outer: for (const group of scene.timingGroups) {
+          for (const ann of group.annotations) {
+            if (ann.type !== selectedTool) continue;
+            const toSvgX = ann.to.x * paWidth + offsetX;
+            const toSvgY = flipped
+              ? (1 - ann.to.y) * paHeight + offsetY
+              : ann.to.y * paHeight + offsetY;
+            const dist = Math.sqrt((pt.x - toSvgX) ** 2 + (pt.y - toSvgY) ** 2);
+            if (dist <= SNAP_RADIUS) {
+              found = { x: toSvgX, y: toSvgY };
+              break outer;
+            }
+          }
+        }
+        setLegSnapTarget(found);
+      } else {
+        setLegSnapTarget(null);
+      }
+
       if (!drawingRef.current) return;
       const to: Point = nearest ? { x: nearest.px, y: nearest.py } : pt;
       const next = { ...drawingRef.current, to };
       drawingRef.current = next;
       setDrawing(next);
     },
-    [getSVGCoords, players, offenseOnly, selectedTool, sceneId, updateAnnotation, paWidth, paHeight, offsetX, offsetY, flipped],
+    [getSVGCoords, players, offenseOnly, selectedTool, sceneId, updateAnnotation, paWidth, paHeight, offsetX, offsetY, flipped, scene],
   );
 
   // Mouse up — commit annotation or finish CP drag
@@ -787,6 +928,7 @@ export default function AnnotationLayer({
       if (!drawingRef.current || !sceneId) {
         setDrawing(null);
         drawingRef.current = null;
+        legExtensionRef.current = null;
         return;
       }
       const { from } = drawingRef.current;
@@ -800,34 +942,47 @@ export default function AnnotationLayer({
       const dx = to.x - from.x;
       const dy = to.y - from.y;
       if (Math.sqrt(dx * dx + dy * dy) > 8) {
-        // Guard: from-player must come from defense pool
-        const fromSnapPool = selectedTool === "guard" ? defenseOnly : players;
-        const fromNearest = findNearestPlayer(from.x, from.y, fromSnapPool);
         // Convert SVG pixel coords to normalised [0-1] court coords.
         // Accounts for OOB side margins (offsetX) and flip.
         const svgToNorm = (svgX: number, svgY: number) => ({
           x: (svgX - offsetX) / paWidth,
           y: flipped ? 1 - (svgY - offsetY) / paHeight : (svgY - offsetY) / paHeight,
         });
-        const annotation: Annotation = {
-          id: crypto.randomUUID(),
-          type: selectedTool as Annotation["type"],
-          from: svgToNorm(from.x, from.y),
-          to:   svgToNorm(to.x,   to.y),
-          fromPlayer: fromNearest
-            ? { side: fromNearest.side, position: fromNearest.position }
-            : null,
-          toPlayer: nearest
+
+        if (legExtensionRef.current) {
+          // Extend an existing annotation with a new leg instead of creating a new one.
+          const { annotationId } = legExtensionRef.current;
+          const newToNorm = svgToNorm(to.x, to.y);
+          const newToPlayer: Annotation["toPlayer"] = nearest
             ? { side: nearest.side, position: nearest.position }
-            : null,
-          controlPoints: [],
-        };
-        addAnnotation(sceneId, selectedTimingStep, annotation);
-        setSelectedAnnotationId(annotation.id);
+            : null;
+          appendAnnotationLeg(sceneId, annotationId, newToNorm, newToPlayer);
+          setSelectedAnnotationId(annotationId);
+        } else {
+          // Guard: from-player must come from defense pool
+          const fromSnapPool = selectedTool === "guard" ? defenseOnly : players;
+          const fromNearest = findNearestPlayer(from.x, from.y, fromSnapPool);
+          const annotation: Annotation = {
+            id: crypto.randomUUID(),
+            type: selectedTool as Annotation["type"],
+            from: svgToNorm(from.x, from.y),
+            to:   svgToNorm(to.x,   to.y),
+            fromPlayer: fromNearest
+              ? { side: fromNearest.side, position: fromNearest.position }
+              : null,
+            toPlayer: nearest
+              ? { side: nearest.side, position: nearest.position }
+              : null,
+            controlPoints: [],
+          };
+          addAnnotation(sceneId, selectedTimingStep, annotation);
+          setSelectedAnnotationId(annotation.id);
+        }
       }
 
       setDrawing(null);
       drawingRef.current = null;
+      legExtensionRef.current = null;
       setSnapTarget(null);
     },
     [
@@ -839,6 +994,7 @@ export default function AnnotationLayer({
       offenseOnly,
       defenseOnly,
       addAnnotation,
+      appendAnnotationLeg,
       setSelectedAnnotationId,
       paWidth,
       paHeight,
@@ -1004,6 +1160,26 @@ export default function AnnotationLayer({
           pointerEvents="none"
           opacity={0.7}
         />
+      )}
+
+      {/* Leg-extension snap ring — shown when hovering over an annotation endpoint
+          to indicate a new leg can be drawn from this point */}
+      {legSnapTarget && isDrawingTool && !drawing && (
+        <g pointerEvents="none">
+          <circle
+            cx={legSnapTarget.x}
+            cy={legSnapTarget.y}
+            r={SNAP_RING_RADIUS}
+            fill="none"
+            stroke="#F97316"
+            strokeWidth={2}
+            strokeDasharray="4 3"
+            opacity={0.85}
+          />
+          {/* Small "+" indicator */}
+          <line x1={legSnapTarget.x - 5} y1={legSnapTarget.y} x2={legSnapTarget.x + 5} y2={legSnapTarget.y} stroke="#F97316" strokeWidth={2} strokeLinecap="round" />
+          <line x1={legSnapTarget.x} y1={legSnapTarget.y - 5} x2={legSnapTarget.x} y2={legSnapTarget.y + 5} stroke="#F97316" strokeWidth={2} strokeLinecap="round" />
+        </g>
       )}
 
       {/* In-progress preview */}

--- a/src/components/editor/ShortcutsOverlay.tsx
+++ b/src/components/editor/ShortcutsOverlay.tsx
@@ -53,6 +53,7 @@ const SECTIONS: ShortcutSection[] = [
       { keys: ["Ctrl", "Shift", "Z"], description: "Redo" },
       { keys: ["Del", "⌫"], description: "Delete selected annotation or scene" },
       { keys: ["Ctrl", "S"], description: "Force save" },
+      { keys: ["drag from endpoint"], description: "Add a leg to an existing movement / cut / dribble arrow" },
     ],
   },
   {

--- a/src/lib/exportPNG.ts
+++ b/src/lib/exportPNG.ts
@@ -412,6 +412,19 @@ function drawArrowHeadBezier(
   drawArrowHead(ctx, tailX, tailY, tx, ty, size, color);
 }
 
+/** Draw a multi-leg polyline through pixel-space waypoints. Returns false if fewer than 2 points. */
+function drawPolyline(
+  ctx: CanvasRenderingContext2D,
+  pts: { x: number; y: number }[],
+): boolean {
+  if (pts.length < 2) return false;
+  ctx.beginPath();
+  ctx.moveTo(pts[0].x, pts[0].y);
+  for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+  ctx.stroke();
+  return true;
+}
+
 function drawAnnotation(
   ctx: CanvasRenderingContext2D,
   ann: Annotation,
@@ -425,10 +438,16 @@ function drawAnnotation(
   const tx = ann.to.x   * width;
   const ty = ann.to.y   * height;
 
-  // Bezier control point (if any)
+  // Multi-leg path support
+  const hasWaypoints = ann.waypoints && ann.waypoints.length > 0;
+  const allPts: { x: number; y: number }[] = hasWaypoints
+    ? [{ x: fx, y: fy }, ...(ann.waypoints ?? []).map((p) => ({ x: p.x * width, y: p.y * height })), { x: tx, y: ty }]
+    : [];
+
+  // Bezier control point (if any — only for single-leg paths)
   let cpx: number | undefined;
   let cpy: number | undefined;
-  if (ann.controlPoints.length > 0) {
+  if (!hasWaypoints && ann.controlPoints.length > 0) {
     cpx = ann.controlPoints[0].x * width;
     cpy = ann.controlPoints[0].y * height;
   }
@@ -441,15 +460,28 @@ function drawAnnotation(
   if (ann.type === "movement") {
     ctx.strokeStyle = "#1E3A5F";
     ctx.lineWidth = 2.5 * scale;
-    drawBezierBody(ctx, fx, fy, tx, ty, cpx, cpy);
-    drawArrowHeadBezier(ctx, fx, fy, tx, ty, arrowSize, "#1E3A5F", cpx, cpy);
+    if (hasWaypoints) {
+      drawPolyline(ctx, allPts);
+      const n = allPts.length;
+      drawArrowHead(ctx, allPts[n - 2].x, allPts[n - 2].y, allPts[n - 1].x, allPts[n - 1].y, arrowSize, "#1E3A5F");
+    } else {
+      drawBezierBody(ctx, fx, fy, tx, ty, cpx, cpy);
+      drawArrowHeadBezier(ctx, fx, fy, tx, ty, arrowSize, "#1E3A5F", cpx, cpy);
+    }
     return;
   }
 
   if (ann.type === "dribble") {
     ctx.strokeStyle = "#1E3A5F";
     ctx.lineWidth = 2.5 * scale;
-    if (cpx !== undefined && cpy !== undefined) {
+    if (hasWaypoints) {
+      // Multi-leg dribble: dashed polyline
+      ctx.setLineDash([5 * scale, 4 * scale]);
+      drawPolyline(ctx, allPts);
+      ctx.setLineDash([]);
+      const n = allPts.length;
+      drawArrowHead(ctx, allPts[n - 2].x, allPts[n - 2].y, allPts[n - 1].x, allPts[n - 1].y, arrowSize, "#1E3A5F");
+    } else if (cpx !== undefined && cpy !== undefined) {
       // Curved dribble: dashed bezier path
       ctx.setLineDash([5 * scale, 4 * scale]);
       drawBezierBody(ctx, fx, fy, tx, ty, cpx, cpy);
@@ -508,9 +540,16 @@ function drawAnnotation(
     ctx.strokeStyle = "#DC2626";
     ctx.lineWidth = 2.5 * scale;
     ctx.setLineDash([7 * scale, 5 * scale]);
-    drawBezierBody(ctx, fx, fy, tx, ty, cpx, cpy);
-    ctx.setLineDash([]);
-    drawArrowHeadBezier(ctx, fx, fy, tx, ty, arrowSize, "#DC2626", cpx, cpy);
+    if (hasWaypoints) {
+      drawPolyline(ctx, allPts);
+      ctx.setLineDash([]);
+      const n = allPts.length;
+      drawArrowHead(ctx, allPts[n - 2].x, allPts[n - 2].y, allPts[n - 1].x, allPts[n - 1].y, arrowSize, "#DC2626");
+    } else {
+      drawBezierBody(ctx, fx, fy, tx, ty, cpx, cpy);
+      ctx.setLineDash([]);
+      drawArrowHeadBezier(ctx, fx, fy, tx, ty, arrowSize, "#DC2626", cpx, cpy);
+    }
     return;
   }
 

--- a/src/lib/exportPdf.ts
+++ b/src/lib/exportPdf.ts
@@ -213,6 +213,18 @@ function arrowHeadBezierPdf(
   drawArrowHead(ctx, tx, ty, tailX, tailY, size);
 }
 
+/** Draw a multi-leg polyline through pixel-space waypoints. */
+function strokePolyline(
+  ctx: CanvasRenderingContext2D,
+  pts: { x: number; y: number }[],
+): void {
+  if (pts.length < 2) return;
+  ctx.beginPath();
+  ctx.moveTo(pts[0].x, pts[0].y);
+  for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+  ctx.stroke();
+}
+
 function drawAnnotation(
   ctx: CanvasRenderingContext2D,
   ann: Annotation,
@@ -225,10 +237,16 @@ function drawAnnotation(
   const tx = ann.to.x * canvasW;
   const ty = ann.to.y * canvasH;
 
-  // Bezier control point (if any)
+  // Multi-leg waypoints
+  const hasWaypoints = ann.waypoints && ann.waypoints.length > 0;
+  const allPts: { x: number; y: number }[] = hasWaypoints
+    ? [{ x: fx, y: fy }, ...(ann.waypoints ?? []).map((p) => ({ x: p.x * canvasW, y: p.y * canvasH })), { x: tx, y: ty }]
+    : [];
+
+  // Bezier control point (if any — single-leg only)
   let cpx: number | undefined;
   let cpy: number | undefined;
-  if (ann.controlPoints.length > 0) {
+  if (!hasWaypoints && ann.controlPoints.length > 0) {
     cpx = ann.controlPoints[0].x * canvasW;
     cpy = ann.controlPoints[0].y * canvasH;
   }
@@ -242,13 +260,31 @@ function drawAnnotation(
   ctx.lineCap = "round";
   ctx.lineJoin = "round";
 
-  if (ann.type === "movement" || ann.type === "pass") {
+  if (ann.type === "movement") {
+    ctx.setLineDash([]);
+    if (hasWaypoints) {
+      strokePolyline(ctx, allPts);
+      const n = allPts.length;
+      drawArrowHead(ctx, allPts[n - 1].x, allPts[n - 1].y, allPts[n - 2].x, allPts[n - 2].y, ANN_ARROW_SIZE);
+    } else {
+      strokeBezier(ctx, fx, fy, tx, ty, cpx, cpy);
+      arrowHeadBezierPdf(ctx, fx, fy, tx, ty, ANN_ARROW_SIZE, cpx, cpy);
+    }
+
+  } else if (ann.type === "pass") {
     ctx.setLineDash([]);
     strokeBezier(ctx, fx, fy, tx, ty, cpx, cpy);
     arrowHeadBezierPdf(ctx, fx, fy, tx, ty, ANN_ARROW_SIZE, cpx, cpy);
 
   } else if (ann.type === "dribble") {
-    if (cpx !== undefined && cpy !== undefined) {
+    if (hasWaypoints) {
+      // Multi-leg dribble: dashed polyline
+      ctx.setLineDash([ANN_LINE_W * 3, ANN_LINE_W * 2]);
+      strokePolyline(ctx, allPts);
+      ctx.setLineDash([]);
+      const n = allPts.length;
+      drawArrowHead(ctx, allPts[n - 1].x, allPts[n - 1].y, allPts[n - 2].x, allPts[n - 2].y, ANN_ARROW_SIZE);
+    } else if (cpx !== undefined && cpy !== undefined) {
       // Curved dribble: dashed bezier
       ctx.setLineDash([ANN_LINE_W * 3, ANN_LINE_W * 2]);
       strokeBezier(ctx, fx, fy, tx, ty, cpx, cpy);
@@ -295,9 +331,16 @@ function drawAnnotation(
 
   } else if (ann.type === "cut") {
     ctx.setLineDash([ANN_LINE_W * 4, ANN_LINE_W * 3]);
-    strokeBezier(ctx, fx, fy, tx, ty, cpx, cpy);
-    ctx.setLineDash([]);
-    arrowHeadBezierPdf(ctx, fx, fy, tx, ty, ANN_ARROW_SIZE, cpx, cpy);
+    if (hasWaypoints) {
+      strokePolyline(ctx, allPts);
+      ctx.setLineDash([]);
+      const n = allPts.length;
+      drawArrowHead(ctx, allPts[n - 1].x, allPts[n - 1].y, allPts[n - 2].x, allPts[n - 2].y, ANN_ARROW_SIZE);
+    } else {
+      strokeBezier(ctx, fx, fy, tx, ty, cpx, cpy);
+      ctx.setLineDash([]);
+      arrowHeadBezierPdf(ctx, fx, fy, tx, ty, ANN_ARROW_SIZE, cpx, cpy);
+    }
 
   } else if (ann.type === "guard") {
     ctx.globalAlpha = 0.85;

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -92,6 +92,18 @@ export interface AppStore {
   moveAnnotationToStep: (sceneId: string, annotationId: string, newStep: number) => void;
   addTimingStep: (sceneId: string) => void;
   removeTimingStep: (sceneId: string, step: number) => void;
+  /**
+   * Extend an existing movement/cut/dribble annotation with an additional leg.
+   * The current `to` endpoint becomes the last waypoint, and `newTo` becomes
+   * the new `to`. Also updates `toPlayer` to the new endpoint's player.
+   * Issue #129: multi-leg player paths.
+   */
+  appendAnnotationLeg: (
+    sceneId: string,
+    annotationId: string,
+    newTo: import("./types").Point,
+    newToPlayer: Annotation["toPlayer"],
+  ) => void;
 
   // ------- Editor state -------
   selectedSceneId: string | null;
@@ -399,6 +411,7 @@ export const useStore = create<AppStore>()(
             const { side, position } = ann.fromPlayer;
             const validSide = side as "offense" | "defense";
             if (ann.type === "movement" || ann.type === "cut" || ann.type === "dribble" || ann.type === "screen") {
+              // ann.to is the final destination (after all waypoints) — use it directly.
               // ann.to is stored in normalised [0-1] coords — same space as PlayerState.x/y.
               newScene.players[validSide] = newScene.players[validSide].map((p) =>
                 p.position === position ? { ...p, x: ann.to.x, y: ann.to.y } : p,
@@ -671,6 +684,36 @@ export const useStore = create<AppStore>()(
               ),
             };
           }),
+        };
+      });
+    },
+
+    appendAnnotationLeg: (sceneId, annotationId, newTo, newToPlayer) => {
+      const state = get();
+      const snapshot = captureSnapshot(state);
+      if (snapshot) useHistoryStore.getState().pushSnapshot(snapshot);
+      set((s) => {
+        if (!s.currentPlay) return s;
+        return {
+          currentPlay: withUpdatedScene(s.currentPlay, sceneId, (sc) => ({
+            ...sc,
+            timingGroups: sc.timingGroups.map((g) => ({
+              ...g,
+              annotations: g.annotations.map((ann) => {
+                if (ann.id !== annotationId) return ann;
+                // Push the current `to` into waypoints, then set newTo as the new `to`.
+                const existingWaypoints = ann.waypoints ?? [];
+                return {
+                  ...ann,
+                  waypoints: [...existingWaypoints, ann.to],
+                  to: newTo,
+                  toPlayer: newToPlayer,
+                  // Clear control points — bezier only applies to single-leg paths
+                  controlPoints: [],
+                };
+              }),
+            })),
+          })),
         };
       });
     },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,6 +42,12 @@ export interface Annotation {
   fromPlayer: { side: string; position: number } | null;
   toPlayer: { side: string; position: number } | null;
   controlPoints: Point[];
+  /**
+   * Optional intermediate waypoints for multi-leg paths (issue #129).
+   * When present, the path is: from → waypoints[0] → ... → waypoints[n-1] → to.
+   * Each element is a normalised [0-1] court coordinate.
+   */
+  waypoints?: Point[];
 }
 
 export interface TimingGroup {


### PR DESCRIPTION
## Summary

- **New `waypoints` field on `Annotation`** — optional `Point[]` storing intermediate stops for multi-leg paths (`from → w[0] → … → w[n-1] → to`). Fully backward-compatible: existing single-leg annotations simply have no `waypoints`.
- **`appendAnnotationLeg` store action** — moves the current `to` into waypoints and sets a new `to`; captures undo snapshot before mutating.
- **Gesture-based leg extension in `AnnotationLayer`** — when a movement / cut / dribble stroke starts within `SNAP_RADIUS` (28 px) of an existing annotation's final endpoint, the stroke extends that annotation rather than creating a new one. An orange dashed ring + "+" icon previews the snap while hovering.
- **Multi-leg rendering** — connected polyline through all points; arrowhead only at the final point. Straight dashes for multi-leg dribble (zigzag only makes sense for single-leg).
- **Export updated** — `exportPNG.ts` and `exportPdf.ts` both handle `waypoints` and render the full path correctly.
- **Shortcuts overlay** — added a tip explaining the drag-from-endpoint gesture.

## How it works (UX)

1. Draw a movement (or cut / dribble) arrow for a player as usual.
2. With the same tool still active, start a new stroke from the arrowhead of the first arrow — an orange ring and "+" appear.
3. Release anywhere on the court: the first arrow gains a new leg. Repeat for as many legs as needed.
4. All legs belong to the **same annotation** in the same timing step, so undo removes all legs at once.

## Test plan

- [ ] Draw a movement arrow; hover the endpoint with Movement tool active — confirm orange ring appears.
- [ ] Drag from the endpoint to a new position — confirm the arrow gains a second leg with arrowhead only at the final point.
- [ ] Add a third leg — confirm A→B→C path renders correctly.
- [ ] Undo once — confirm all legs disappear (single annotation).
- [ ] Repeat with Cut and Dribble tools.
- [ ] Add scene after multi-leg path — confirm player starts at the final destination.
- [ ] Export PNG and PDF — confirm multi-leg paths render correctly.
- [ ] Bezier curve (single-leg movement): confirm no regression.
- [ ] Guard / Pass / Screen / Handoff annotations: confirm no leg-extension indicator appears (not extendable).

## Notes for squash-merge
Please **squash-and-merge** this PR to keep a linear history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)