### PR TITLE
PDF multi-layout grid export

### DIFF
--- a/src/components/editor/ExportMenu.tsx
+++ b/src/components/editor/ExportMenu.tsx
@@ -15,7 +15,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { useStore, selectEditorScene } from "@/lib/store";
 import { exportSceneAsPNG, type ExportResolution } from "@/lib/exportPNG";
 import { exportPlayAsGIF, type GifResolution } from "@/lib/exportGIF";
-import { exportPlayToPdf } from "@/lib/exportPdf";
+import { exportPlayToPdf, type PdfLayout } from "@/lib/exportPdf";
 
 // ---------------------------------------------------------------------------
 // Resolution options (PNG)
@@ -131,6 +131,7 @@ export default function ExportMenu() {
 
   // PDF settings
   const [pdfExportSteps, setPdfExportSteps] = useState(false);
+  const [pdfLayout, setPdfLayout] = useState<PdfLayout>("1x1");
 
   const menuRef = useRef<HTMLDivElement>(null);
   const isExporting = exportMode !== "idle";
@@ -177,11 +178,11 @@ export default function ExportMenu() {
     setExportMode("pdf");
     setOpen(false);
     try {
-      await exportPlayToPdf(currentPlay, { exportSteps: pdfExportSteps });
+      await exportPlayToPdf(currentPlay, { exportSteps: pdfExportSteps, layout: pdfLayout });
     } finally {
       setExportMode("idle");
     }
-  }, [currentPlay, pdfExportSteps]);
+  }, [currentPlay, pdfExportSteps, pdfLayout]);
 
   const handleExportGIF = useCallback(async () => {
     if (!currentPlay) return;
@@ -372,7 +373,27 @@ export default function ExportMenu() {
               Export Play Document
             </p>
           </div>
-          <div className="px-4 py-3">
+          <div className="px-4 py-3 flex flex-col gap-3">
+            <div>
+              <p className="mb-1.5 text-xs font-medium text-gray-600">Layout</p>
+              <div className="flex gap-1.5 flex-wrap">
+                {(["1x1", "2x1", "2x2", "3x2"] as PdfLayout[]).map((l) => (
+                  <button
+                    key={l}
+                    onClick={() => setPdfLayout(l)}
+                    aria-pressed={pdfLayout === l}
+                    className={[
+                      "rounded px-2.5 py-1 text-xs font-medium transition-colors",
+                      pdfLayout === l
+                        ? "bg-orange-100 text-orange-700"
+                        : "bg-gray-100 text-gray-600 hover:bg-gray-200",
+                    ].join(" ")}
+                  >
+                    {l}
+                  </button>
+                ))}
+              </div>
+            </div>
             <label className="flex cursor-pointer items-center gap-2.5">
               <input
                 type="checkbox"
@@ -380,7 +401,7 @@ export default function ExportMenu() {
                 onChange={(e) => setPdfExportSteps(e.target.checked)}
                 className="accent-orange-600"
               />
-              <span className="text-sm text-gray-700">One page per step</span>
+              <span className="text-sm text-gray-700">Export steps</span>
               <span className="text-xs text-gray-400">(cumulative reveal)</span>
             </label>
           </div>
@@ -399,7 +420,7 @@ export default function ExportMenu() {
                 <span className="block text-xs text-gray-500">
                   All {currentPlay?.scenes.length ?? 0} scene
                   {(currentPlay?.scenes.length ?? 0) !== 1 ? "s" : ""}
-                  {pdfExportSteps ? " · one page per step" : " · one page per scene"}
+                  {pdfExportSteps ? " · per step" : " · per scene"} · {pdfLayout} layout
                 </span>
               </span>
             </button>

--- a/src/lib/exportPdf.ts
+++ b/src/lib/exportPdf.ts
@@ -471,89 +471,138 @@ function renderScene(
 // PDF assembly
 // ---------------------------------------------------------------------------
 
+export type PdfLayout = "1x1" | "2x1" | "2x2" | "3x2";
+
 export interface ExportPdfOptions {
-  /** When true, renders one page per timing step (cumulative reveal). Default: false. */
+  /** When true, renders one item per timing step (cumulative reveal). Default: false. */
   exportSteps?: boolean;
+  /** Grid layout: columns × rows per page. Default "1x1". */
+  layout?: PdfLayout;
 }
+
+const LAYOUT_GRID: Record<PdfLayout, { cols: number; rows: number }> = {
+  "1x1": { cols: 1, rows: 1 },
+  "2x1": { cols: 2, rows: 1 },
+  "2x2": { cols: 2, rows: 2 },
+  "3x2": { cols: 3, rows: 2 },
+};
 
 /**
  * Generates and downloads a PDF of the given play.
- * Default: one page per scene. With exportSteps: one page per timing step.
+ * Supports 1×1 (full page), 2×1, 2×2, and 3×2 grid layouts.
  */
 export async function exportPlayToPdf(play: Play, options: ExportPdfOptions = {}): Promise<void> {
-  const { exportSteps = false } = options;
+  const { exportSteps = false, layout = "1x1" } = options;
+  const { cols, rows } = LAYOUT_GRID[layout];
+  const itemsPerPage = cols * rows;
 
   // Dynamic import keeps jsPDF out of the SSR bundle
   const { jsPDF } = await import("jspdf");
 
-  const PAGE_W = 210;   // A4 portrait width (mm)
-  const PAGE_H = 297;   // A4 portrait height (mm)
-  const MARGIN = 12;    // page margin (mm)
-  const HEADER_H = 16;  // height reserved for scene/play title row (mm)
+  const PAGE_W = 210;    // A4 portrait width (mm)
+  const PAGE_H = 297;    // A4 portrait height (mm)
+  const MARGIN = 10;     // outer page margin (mm)
+  const PAGE_HEADER_H = cols === 1 && rows === 1 ? 14 : 10; // play title bar
+  const CELL_LABEL_H = cols === 1 && rows === 1 ? 0 : 7;    // per-cell label (not needed for 1×1)
+  const CELL_GAP = 4;    // gap between cells (mm)
 
   const usableW = PAGE_W - 2 * MARGIN;
-  const usableH = PAGE_H - 2 * MARGIN - HEADER_H;
+  const usableH = PAGE_H - 2 * MARGIN - PAGE_HEADER_H;
+  const cellW = (usableW - (cols - 1) * CELL_GAP) / cols;
+  const cellH = (usableH - (rows - 1) * CELL_GAP) / rows;
+  const imgAreaH = cellH - CELL_LABEL_H;
 
   const pdf = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
 
+  // --- Collect all items to render ---
+  interface RenderItem {
+    scene: typeof play.scenes[number];
+    maxStep: number;
+    label: string;
+  }
+  const items: RenderItem[] = [];
   const scenes = [...play.scenes].sort((a, b) => a.order - b.order);
-  let pageIndex = 0;
-
   for (const scene of scenes) {
-    const sceneFlipped = (scene.flipped ?? play.flipped) === true;
     const sortedGroups = [...scene.timingGroups].sort((a, b) => a.step - b.step);
     const steps = exportSteps ? sortedGroups.map((g) => g.step) : [Infinity];
-
     for (const maxStep of steps) {
-      if (pageIndex > 0) pdf.addPage();
-      pageIndex++;
+      const stepLabel = exportSteps && maxStep !== Infinity ? ` · Step ${maxStep}` : "";
+      items.push({ scene, maxStep, label: `Scene ${scene.order}${stepLabel}` });
+    }
+  }
 
+  // --- Render pages ---
+  const totalPages = Math.ceil(items.length / itemsPerPage);
+
+  for (let pageIdx = 0; pageIdx < totalPages; pageIdx++) {
+    if (pageIdx > 0) pdf.addPage();
+
+    // Page header: play title + divider
+    pdf.setFont("helvetica", "normal");
+    pdf.setFontSize(cols === 1 && rows === 1 ? 9 : 8);
+    pdf.setTextColor(156, 163, 175);
+    pdf.text(play.title, PAGE_W - MARGIN, MARGIN + (PAGE_HEADER_H - 4), { align: "right" });
+    pdf.setDrawColor(229, 231, 235);
+    pdf.setLineWidth(0.3);
+    pdf.line(MARGIN, MARGIN + PAGE_HEADER_H - 2, PAGE_W - MARGIN, MARGIN + PAGE_HEADER_H - 2);
+
+    const pageItems = items.slice(pageIdx * itemsPerPage, (pageIdx + 1) * itemsPerPage);
+
+    for (let i = 0; i < pageItems.length; i++) {
+      const { scene, maxStep, label } = pageItems[i];
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+
+      const cellX = MARGIN + col * (cellW + CELL_GAP);
+      const cellY = MARGIN + PAGE_HEADER_H + row * (cellH + CELL_GAP);
+
+      // Per-cell label (only in multi-cell layouts)
+      if (CELL_LABEL_H > 0) {
+        pdf.setFont("helvetica", "bold");
+        pdf.setFontSize(7);
+        pdf.setTextColor(31, 41, 55);
+        pdf.text(label, cellX, cellY + 5);
+        if (scene.note) {
+          pdf.setFont("helvetica", "normal");
+          pdf.setFontSize(6);
+          pdf.setTextColor(107, 114, 128);
+          const labelW = pdf.getTextWidth(label);
+          pdf.text(scene.note, cellX + labelW + 2, cellY + 5);
+        }
+      } else {
+        // 1×1: full-width header with scene label + divider
+        pdf.setFont("helvetica", "bold");
+        pdf.setFontSize(11);
+        pdf.setTextColor(31, 41, 55);
+        pdf.text(label, MARGIN, MARGIN + 8);
+        if (scene.note) {
+          const labelW = pdf.getTextWidth(label);
+          pdf.setFont("helvetica", "normal");
+          pdf.setFontSize(9);
+          pdf.setTextColor(107, 114, 128);
+          pdf.text(scene.note, MARGIN + labelW + 3, MARGIN + 8);
+        }
+      }
+
+      // Render court canvas
+      const sceneFlipped = (scene.flipped ?? play.flipped) === true;
       const canvas = renderScene(scene, play.courtType, sceneFlipped, maxStep);
       const imgData = canvas.toDataURL("image/jpeg", 0.92);
 
-      // Scale to fit usable area while preserving aspect ratio
+      // Scale court image to fit cell image area, preserving aspect ratio
       const imgAspect = canvas.width / canvas.height;
-      let imgW: number;
-      let imgH: number;
-      if (imgAspect >= usableW / usableH) {
-        imgW = usableW;
-        imgH = usableW / imgAspect;
+      const imgAreaY = cellY + CELL_LABEL_H;
+      let imgW: number, imgH: number;
+      if (imgAspect >= cellW / imgAreaH) {
+        imgW = cellW;
+        imgH = cellW / imgAspect;
       } else {
-        imgH = usableH;
-        imgW = usableH * imgAspect;
+        imgH = imgAreaH;
+        imgW = imgAreaH * imgAspect;
       }
-      const imgX = MARGIN + (usableW - imgW) / 2;
-      const imgY = MARGIN + HEADER_H;
+      const imgX = cellX + (cellW - imgW) / 2;
+      const imgY = imgAreaY + (imgAreaH - imgH) / 2;
 
-      // --- Header row ---
-      const stepLabel = exportSteps && maxStep !== Infinity ? ` · Step ${maxStep}` : "";
-      const sceneLabel = `Scene ${scene.order}${stepLabel}`;
-
-      pdf.setFont("helvetica", "bold");
-      pdf.setFontSize(11);
-      pdf.setTextColor(31, 41, 55);
-      pdf.text(sceneLabel, MARGIN, MARGIN + 8);
-
-      if (scene.note) {
-        const labelW = pdf.getTextWidth(sceneLabel);
-        pdf.setFont("helvetica", "normal");
-        pdf.setFontSize(9);
-        pdf.setTextColor(107, 114, 128);
-        pdf.text(scene.note, MARGIN + labelW + 3, MARGIN + 8);
-      }
-
-      // Play title — right-aligned
-      pdf.setFont("helvetica", "normal");
-      pdf.setFontSize(9);
-      pdf.setTextColor(156, 163, 175);
-      pdf.text(play.title, PAGE_W - MARGIN, MARGIN + 8, { align: "right" });
-
-      // Thin divider under header
-      pdf.setDrawColor(229, 231, 235);
-      pdf.setLineWidth(0.3);
-      pdf.line(MARGIN, MARGIN + HEADER_H - 2, PAGE_W - MARGIN, MARGIN + HEADER_H - 2);
-
-      // --- Court image ---
       pdf.addImage(imgData, "JPEG", imgX, imgY, imgW, imgH);
     }
   }


### PR DESCRIPTION
## Summary
- Add `layout` option to PDF export: `1x1` (full page, unchanged), `2x1`, `2x2`, `3x2`
- Multiple scenes/steps rendered in a grid per page with per-cell scene labels
- Layout picker added to Export menu alongside the existing per-step toggle
- Closes #148

## Test plan
- [ ] Export a play with multiple scenes at each layout — verify correct grid
- [ ] Combine with "Export steps" — verify each step gets its own cell
- [ ] Verify 1×1 still looks identical to before (full page, large header)
- [ ] Verify scene labels + notes appear correctly per cell