### PR TITLE
Fix share view: players misaligned on first load + restart button

### DIFF
--- a/src/app/view/[shareToken]/page.tsx
+++ b/src/app/view/[shareToken]/page.tsx
@@ -167,6 +167,11 @@ export default function SharedPlayViewPage({ params }: SharedPlayViewPageProps) 
         e.preventDefault();
         setIsPlaying(false);
         setStepIndex((si) => Math.max(si - 1, 0));
+      } else if (e.code === "Home") {
+        e.preventDefault();
+        setIsPlaying(false);
+        setSceneIndex(0);
+        setStepIndex(0);
       } else if (e.code === "BracketLeft") {
         e.preventDefault();
         setIsPlaying(false);
@@ -302,6 +307,17 @@ export default function SharedPlayViewPage({ params }: SharedPlayViewPageProps) 
         {/* Scene navigation */}
         {hasMultipleScenes && (
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            {/* Go to beginning */}
+            <button
+              onClick={() => { setIsPlaying(false); setSceneIndex(0); setStepIndex(0); }}
+              disabled={sceneIndex === 0 && stepIndex === 0}
+              aria-label="Go to beginning"
+              title="Go to beginning"
+              style={{ padding: "6px 10px", borderRadius: 8, border: "1.5px solid #E5E7EB", background: "#fff", fontSize: 13, fontWeight: 500, color: sceneIndex === 0 && stepIndex === 0 ? "#D1D5DB" : "#374151", cursor: sceneIndex === 0 && stepIndex === 0 ? "default" : "pointer" }}
+            >
+              ⏮
+            </button>
+
             <button
               onClick={() => { setIsPlaying(false); setSceneIndex((i) => Math.max(0, i - 1)); }}
               disabled={sceneIndex === 0}
@@ -336,7 +352,7 @@ export default function SharedPlayViewPage({ params }: SharedPlayViewPageProps) 
 
         {/* Keyboard hint */}
         <p style={{ margin: 0, fontSize: 11, color: "#C4C4C4" }}>
-          Space: play/pause · ← →: step · [ ]: scene
+          Space: play/pause · ← →: step · [ ]: scene · Home: restart
         </p>
       </div>
     </main>

--- a/src/components/players/CourtWithPlayers.tsx
+++ b/src/components/players/CourtWithPlayers.tsx
@@ -207,6 +207,12 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
   const flippedRef = useRef(flipped);
   flippedRef.current = flipped;
 
+  // Always-current ref for scene prop — lets handleCourtReady (stable, no deps)
+  // fall back to prop-based scene data when the Zustand store is empty
+  // (e.g. read-only viewers that load a play outside the store).
+  const scenePropRef = useRef(scene);
+  scenePropRef.current = scene;
+
   // Track the last scene ID so we can reinitialise pixel positions on scene switch
   const prevSceneIdRef = useRef<string | null>(null);
 
@@ -290,6 +296,8 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
       // First render — read from the Zustand store directly so this callback
       // does not need `scene` in its dep array (which would recreate it on every
       // visibility toggle, causing Court to redraw unnecessarily).
+      // Fall back to the scene prop ref for read-only viewers (share view) where
+      // the play is not loaded into the store.
       if (!prevSize) {
         const storeState = useStore.getState();
         const currentScene =
@@ -297,6 +305,7 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
             (sc) => sc.id === storeState.selectedSceneId,
           ) ??
           storeState.currentPlay?.scenes[0] ??
+          scenePropRef.current ??
           null;
 
         const offenseStoreState = currentScene?.players.offense ?? defaultPlayers(OFFENSE_DEFAULTS);


### PR DESCRIPTION
## Summary
- **Players at wrong positions on first load**: `handleCourtReady` (stable, no deps) reads from `useStore.getState()` for the initial player positions. In the share view the play is in local React state, not the store, so `currentPlay` is null and players fall back to `OFFENSE_DEFAULTS`. The `useEffect([scene])` re-projection skips first render intentionally to avoid double-init in the editor — so players stay at defaults until the next scene navigation.

  Fix: add `scenePropRef` (same pattern as `flippedRef`) so `handleCourtReady` can fall back to the prop-based scene when the store is empty.

- **"Go to beginning" button**: added ⏮ button that resets to scene 1 step 1. Disabled when already at start. Also wired to `Home` keyboard shortcut.

## Test plan
- [ ] Open share link → first scene shows players at correct positions and arrows originate from them
- [ ] ⏮ button resets to scene 1 / step 1 from any point
- [ ] ⏮ button is disabled when already at scene 1 step 1
- [ ] `Home` key also resets to beginning
- [ ] Editor and presentation mode unaffected (store-based path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)