### PR TITLE
Fix video export: WebCodecs H.264 MP4 (QuickTime + WhatsApp compatible)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "firebase": "^12.9.0",
         "gifenc": "^1.0.3",
         "jspdf": "^4.2.0",
+        "mp4-muxer": "^5.2.2",
         "next": "14.2.35",
         "react": "^18",
         "react-dom": "^18",
@@ -1249,6 +1250,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.18.tgz",
+      "integrity": "sha512-vAvE8C9DGWR+tkb19xyjk1TSUlJ7RUzzp4a9Anu7mwBT+fpyePWK1UxmH14tMO5zHmrnrRIMg5NutnnDztLxgg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -1312,6 +1319,12 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/wicg-file-system-access": {
+      "version": "2020.9.8",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.8.tgz",
+      "integrity": "sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.0",
@@ -4991,6 +5004,17 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mp4-muxer": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/mp4-muxer/-/mp4-muxer-5.2.2.tgz",
+      "integrity": "sha512-dhozjTywI0h2qFzeShagt8YYw811fh1XlwiDCE2f6Aeqf6xG2CyuShoSa5E0AZDO8pPF0JOZ3wOmWBNWIGdSpQ==",
+      "deprecated": "This library is superseded by Mediabunny. Please migrate to it.",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "^0.1.6",
+        "@types/wicg-file-system-access": "^2020.9.5"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "firebase": "^12.9.0",
     "gifenc": "^1.0.3",
     "jspdf": "^4.2.0",
+    "mp4-muxer": "^5.2.2",
     "next": "14.2.35",
     "react": "^18",
     "react-dom": "^18",

--- a/src/lib/exportVideo.ts
+++ b/src/lib/exportVideo.ts
@@ -1,22 +1,23 @@
 "use client";
 
 /**
- * Video (MP4/WebM) export utility — renders the full play animation as a video.
+ * Video (H.264 MP4) export utility — renders the full play animation as a video.
  *
- * Reuses the same court/player/annotation rendering pipeline as exportGIF.ts
- * but encodes via the browser's MediaRecorder API instead of gifenc.
+ * Uses the WebCodecs API (VideoEncoder) + mp4-muxer to produce a proper H.264
+ * MP4 file that plays in QuickTime, WhatsApp, iMessage, and all video players.
  *
- * Why video instead of GIF:
- *   - WhatsApp and most messaging apps play video files natively and animated.
- *   - GIF files are treated as static images by WhatsApp's media picker.
- *   - Video files are ~10× smaller than equivalent GIFs.
+ * Why not MediaRecorder?
+ *   Chrome's MediaRecorder only produces WebM (VP8/VP9), which QuickTime and
+ *   WhatsApp do not support. WebCodecs gives us true H.264 in all browsers.
  *
- * Format selection (automatic, based on browser support):
- *   - Safari (iPhone/Mac): H.264 MP4  → downloads as .mp4
- *   - Chrome / Firefox:    VP9 WebM   → downloads as .webm
- *   Both formats are accepted by WhatsApp when sent as a video.
+ * Browser support: Chrome 94+, Safari 16.4+, Edge 94+.
+ * Firefox: WebCodecs H.264 is behind a flag — falls back to MediaRecorder WebM.
+ *
+ * Key advantage over MediaRecorder: frames are encoded without waiting real time,
+ * so a 3-scene play with 2-second steps exports in seconds, not minutes.
  */
 
+import { Muxer, ArrayBufferTarget } from "mp4-muxer";
 import type { Play, Annotation } from "./types";
 import { COURT_ASPECT_RATIO } from "@/components/court/courtDimensions";
 import {
@@ -36,33 +37,106 @@ export interface ExportVideoOptions {
 }
 
 // ---------------------------------------------------------------------------
-// Format detection
+// WebCodecs H.264 export (primary path)
 // ---------------------------------------------------------------------------
 
-function detectFormat(): { mimeType: string; ext: "mp4" | "webm" } {
-  const candidates = [
-    { mimeType: "video/mp4;codecs=h264", ext: "mp4" as const },
-    { mimeType: "video/mp4",             ext: "mp4" as const },
-    { mimeType: "video/webm;codecs=vp9", ext: "webm" as const },
-    { mimeType: "video/webm;codecs=vp8", ext: "webm" as const },
-    { mimeType: "video/webm",            ext: "webm" as const },
-  ];
-  for (const f of candidates) {
-    if (typeof MediaRecorder !== "undefined" && MediaRecorder.isTypeSupported(f.mimeType)) {
-      return f;
+async function exportViaWebCodecs(
+  play: Play,
+  filename: string,
+  options: ExportVideoOptions,
+): Promise<void> {
+  const { speed = 1, resolution = "sd", onProgress } = options;
+
+  const width  = RESOLUTION_WIDTH[resolution];
+  const height = Math.round(width / COURT_ASPECT_RATIO);
+  // H.264 requires dimensions divisible by 2
+  const encW = width  % 2 === 0 ? width  : width  - 1;
+  const encH = height % 2 === 0 ? height : height - 1;
+
+  const canvas = document.createElement("canvas");
+  canvas.width  = encW;
+  canvas.height = encH;
+
+  const muxer = new Muxer({
+    target: new ArrayBufferTarget(),
+    video: { codec: "avc", width: encW, height: encH },
+    fastStart: "in-memory",
+  });
+
+  const encoder = new VideoEncoder({
+    output: (chunk, meta) => muxer.addVideoChunk(chunk, meta),
+    error: (e) => { throw e; },
+  });
+
+  encoder.configure({
+    codec: "avc1.4d0028", // H.264 High Profile Level 4.0
+    width: encW,
+    height: encH,
+    bitrate: resolution === "hd" ? 3_000_000 : 1_500_000,
+    framerate: 30,
+    latencyMode: "quality",
+  });
+
+  const scenes = [...play.scenes].sort((a, b) => a.order - b.order);
+
+  let totalSteps = 0;
+  for (const scene of scenes) totalSteps += scene.timingGroups.length + 1;
+  let stepsRendered = 0;
+
+  let timestampUs = 0; // running encode timestamp in microseconds
+
+  const encodeFrame = (durationMs: number, keyFrame: boolean) => {
+    const durationUs = Math.round((durationMs / speed) * 1000);
+    const frame = new VideoFrame(canvas, { timestamp: timestampUs, duration: durationUs });
+    encoder.encode(frame, { keyFrame });
+    frame.close();
+    timestampUs += durationUs;
+  };
+
+  for (let si = 0; si < scenes.length; si++) {
+    const scene = scenes[si];
+    const sceneFlipped = (scene.flipped ?? play.flipped) === true;
+    const sortedGroups = [...scene.timingGroups].sort((a, b) => a.step - b.step);
+    const cumulativeAnnotations: Annotation[] = [];
+
+    for (let gi = 0; gi < sortedGroups.length; gi++) {
+      const group = sortedGroups[gi];
+      cumulativeAnnotations.push(...group.annotations);
+      renderFrame(canvas, scene, cumulativeAnnotations, encW, encH, sceneFlipped);
+      encodeFrame(group.duration, si === 0 && gi === 0);
+
+      stepsRendered++;
+      onProgress?.(stepsRendered / totalSteps);
+      // Yield occasionally so the UI stays responsive
+      if (stepsRendered % 5 === 0) await new Promise<void>((r) => setTimeout(r, 0));
     }
+
+    // Hold frame
+    const holdMs = si === scenes.length - 1 ? FINAL_HOLD_MS : SCENE_HOLD_MS;
+    const cumulativeCopy = [...cumulativeAnnotations];
+    renderFrame(canvas, scene, cumulativeCopy, encW, encH, sceneFlipped);
+    encodeFrame(holdMs, false);
+
+    stepsRendered++;
+    onProgress?.(stepsRendered / totalSteps);
   }
-  return { mimeType: "video/webm", ext: "webm" };
+
+  await encoder.flush();
+  muxer.finalize();
+
+  const { buffer } = muxer.target;
+  const blob = new Blob([buffer], { type: "video/mp4" });
+  triggerDownload(blob, `${filename}.mp4`);
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// MediaRecorder fallback (Firefox / older browsers)
 // ---------------------------------------------------------------------------
 
-export async function exportPlayAsVideo(
+async function exportViaMediaRecorder(
   play: Play,
-  filename = "play",
-  options: ExportVideoOptions = {},
+  filename: string,
+  options: ExportVideoOptions,
 ): Promise<void> {
   const { speed = 1, resolution = "sd", onProgress } = options;
 
@@ -73,21 +147,17 @@ export async function exportPlayAsVideo(
   canvas.width  = width;
   canvas.height = height;
 
-  const format  = detectFormat();
-  const stream  = canvas.captureStream(30);
-  const recorder = new MediaRecorder(
-    stream,
-    format.mimeType ? { mimeType: format.mimeType } : {},
-  );
+  const mimeType = MediaRecorder.isTypeSupported("video/webm;codecs=vp9")
+    ? "video/webm;codecs=vp9"
+    : "video/webm";
 
+  const stream   = canvas.captureStream(30);
+  const recorder = new MediaRecorder(stream, { mimeType });
   const chunks: BlobPart[] = [];
   recorder.ondataavailable = (e) => { if (e.data.size > 0) chunks.push(e.data); };
-
   recorder.start();
 
-  // Sort scenes by order
   const scenes = [...play.scenes].sort((a, b) => a.order - b.order);
-
   let totalSteps = 0;
   for (const scene of scenes) totalSteps += scene.timingGroups.length + 1;
   let stepsRendered = 0;
@@ -106,27 +176,56 @@ export async function exportPlayAsVideo(
       onProgress?.(stepsRendered / totalSteps);
     }
 
-    // Hold frame between scenes
     const holdMs = (si === scenes.length - 1 ? FINAL_HOLD_MS : SCENE_HOLD_MS) / speed;
-    renderFrame(canvas, scene, cumulativeAnnotations, width, height, sceneFlipped);
+    renderFrame(canvas, scene, [...cumulativeAnnotations], width, height, sceneFlipped);
     await new Promise<void>((r) => setTimeout(r, holdMs));
     stepsRendered++;
     onProgress?.(stepsRendered / totalSteps);
   }
 
-  // Stop and collect
   await new Promise<void>((resolve) => {
     recorder.onstop = () => resolve();
     recorder.stop();
   });
 
-  const blob = new Blob(chunks, { type: format.mimeType });
-  const url  = URL.createObjectURL(blob);
-  const a    = document.createElement("a");
+  const blob = new Blob(chunks, { type: mimeType });
+  triggerDownload(blob, `${filename}.webm`);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a   = document.createElement("a");
   a.href     = url;
-  a.download = `${filename}.${format.ext}`;
+  a.download = filename;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
+}
+
+function supportsWebCodecs(): boolean {
+  return (
+    typeof VideoEncoder !== "undefined" &&
+    typeof VideoFrame   !== "undefined"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function exportPlayAsVideo(
+  play: Play,
+  filename = "play",
+  options: ExportVideoOptions = {},
+): Promise<void> {
+  if (supportsWebCodecs()) {
+    await exportViaWebCodecs(play, filename, options);
+  } else {
+    await exportViaMediaRecorder(play, filename, options);
+  }
 }


### PR DESCRIPTION
## Problem
`MediaRecorder` on Chrome produces WebM (VP8/VP9). QuickTime doesn't play WebM, and WhatsApp rejects it.

## Fix
Replace `MediaRecorder` with **WebCodecs `VideoEncoder` + `mp4-muxer`** — produces a real H.264 MP4 file that works in QuickTime, WhatsApp, iMessage, and all video players.

## Details
- **Primary path** (Chrome 94+, Safari 16.4+): `VideoEncoder` → H.264 High Profile → `.mp4` via `mp4-muxer`
- **Fallback** (Firefox / older browsers): `MediaRecorder` → VP9 WebM → `.webm`
- **Faster export**: WebCodecs encodes without waiting real time — no more sitting through the full animation duration
- Adds `mp4-muxer` dependency (pure JS, no WASM)

## Test plan
- [ ] Export video on Chrome → QuickTime opens and plays it
- [ ] Export video on Chrome → WhatsApp accepts and plays it animated
- [ ] Export video on Safari → same result
- [ ] SD and HD resolutions both work
- [ ] Speed options (0.5×/1×/2×) produce correct playback speed

🤖 Generated with [Claude Code](https://claude.com/claude-code)