### PR TITLE
Fix presentation mode: ⏮ icon and auto-reset to beginning

### DIFF
--- a/src/components/editor/PresentationOverlay.tsx
+++ b/src/components/editor/PresentationOverlay.tsx
@@ -82,8 +82,8 @@ function SceneForwardIcon() {
 
 function RestartIcon() {
   return (
-    <svg viewBox="0 0 24 24" width={18} height={18} fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M4 6h16M4 6l4-4M4 6l4 4M20 18H4M20 18l-4-4M20 18l-4 4" />
+    <svg viewBox="0 0 24 24" width={18} height={18} fill="currentColor" aria-hidden="true">
+      <path d="M6 4h2v16H6zM18 4L8 12l10 8V4z" />
     </svg>
   );
 }
@@ -126,6 +126,23 @@ export default function PresentationOverlay() {
 
   // Effective flip: scene override > play default
   const effectiveFlipped = ((scene?.flipped ?? currentPlay?.flipped) === true);
+
+  // Reset to beginning when entering presentation mode
+  useEffect(() => {
+    const state = useStore.getState();
+    const scenes = state.currentPlay?.scenes ?? [];
+    const sorted = [...scenes].sort((a, b) => a.order - b.order);
+    const first = sorted[0];
+    if (first) {
+      const firstGroups = [...first.timingGroups].sort((a, b) => a.step - b.step);
+      state.pausePlayback();
+      useStore.setState({
+        currentSceneIndex: 0,
+        currentStep: firstGroups[0]?.step ?? 1,
+        selectedSceneId: first.id,
+      });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Auto-hide controls after 3 s of inactivity
   const [controlsVisible, setControlsVisible] = useState(true);


### PR DESCRIPTION
## Summary
- The ⏮ (go-to-beginning) button was rendering as ↔ (two opposing arrows) due to a wrong SVG path — fixed with a proper filled vertical-bar + left-triangle shape
- Presentation mode was opening at whatever step the editor was last at, causing all annotations to appear simultaneously — now auto-resets to scene 1 / step 1 on open

## Test plan
- [ ] Open a play with multiple scenes and multi-step annotations in the editor
- [ ] Navigate to a later step in the editor
- [ ] Enter presentation mode — should start at scene 1, step 1 (only first step's annotations visible)
- [ ] Confirm ⏮ button looks like a skip-to-beginning icon (vertical bar + left triangle)
- [ ] Step through and confirm annotations reveal one step at a time
- [ ] Confirm "cut" lines (or any step-2+ annotations) are absent at step 1 and appear correctly at their step

🤖 Generated with [Claude Code](https://claude.com/claude-code)