### PR TITLE
feat: tap player token to toggle visibility (#162)

### DIFF
--- a/src/components/players/CourtWithPlayers.tsx
+++ b/src/components/players/CourtWithPlayers.tsx
@@ -165,11 +165,12 @@ export interface CourtWithPlayersProps {
 }
 
 export default function CourtWithPlayers({ sceneId, scene, variant = "half", className, readOnly = false, flipped = false, activeStep }: CourtWithPlayersProps) {
-  const updatePlayerState  = useStore((s) => s.updatePlayerState);
-  const updateBallState    = useStore((s) => s.updateBallState);
-  const displayMode        = useStore((s) => s.playerDisplayMode);
-  const playerNames        = useStore((s) => s.playerNames);
-  const playColors         = useStore((s) => s.currentPlay?.colors);
+  const updatePlayerState        = useStore((s) => s.updatePlayerState);
+  const updateBallState          = useStore((s) => s.updateBallState);
+  const togglePlayerVisibility   = useStore((s) => s.togglePlayerVisibility);
+  const displayMode              = useStore((s) => s.playerDisplayMode);
+  const playerNames              = useStore((s) => s.playerNames);
+  const playColors               = useStore((s) => s.currentPlay?.colors);
 
   // Court layout reported by the Court canvas
   const [courtSize, setCourtSize] = useState<{
@@ -582,54 +583,66 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
             {/* Defensive players (rendered first = underneath offensive) */}
             {defensePx
               ?.filter((p) => {
-                // Read visibility from scene (Zustand source of truth) so that
-                // togglePlayerVisibility changes are reflected immediately
-                // without relying on local pixel state staying in sync.
+                // In readOnly mode, hide invisible players entirely.
+                // In editor mode, render all players (hidden ones appear as ghosts).
+                if (!readOnly) return true;
                 const scenePlayer = defenseVisible?.find((sp) => sp.position === p.position);
                 return scenePlayer ? scenePlayer.visible : p.visible;
               })
-              .map((p) => (
-                <PlayerToken
-                  key={`defense-${p.position}`}
-                  side="defense"
-                  position={p.position}
-                  cx={p.px}
-                  cy={p.py}
-                  courtBounds={{ width: courtSize.width, height: courtSize.height, minY: playAreaRef.current.offsetY > 0 ? playAreaRef.current.offsetY : undefined }}
-                  onDrag={(x, y) => handleDefenseDrag(p.position, x, y)}
-                  onDragEnd={(x, y) => handleDefenseDragEnd(p.position, x, y)}
-                  displayMode={displayMode}
-                  playerName={playerNames[`defense-${p.position}`]}
-                  radius={tokenRadius}
-                  defenseColor={playColors?.defense}
-                />
-              ))}
+              .map((p) => {
+                const scenePlayer = defenseVisible?.find((sp) => sp.position === p.position);
+                const isVisible = scenePlayer ? scenePlayer.visible : p.visible;
+                return (
+                  <PlayerToken
+                    key={`defense-${p.position}`}
+                    side="defense"
+                    position={p.position}
+                    cx={p.px}
+                    cy={p.py}
+                    courtBounds={{ width: courtSize.width, height: courtSize.height, minY: playAreaRef.current.offsetY > 0 ? playAreaRef.current.offsetY : undefined }}
+                    onDrag={(x, y) => handleDefenseDrag(p.position, x, y)}
+                    onDragEnd={(x, y) => handleDefenseDragEnd(p.position, x, y)}
+                    onTap={sceneId ? () => togglePlayerVisibility(sceneId, "defense", p.position) : undefined}
+                    visible={isVisible}
+                    displayMode={displayMode}
+                    playerName={playerNames[`defense-${p.position}`]}
+                    radius={tokenRadius}
+                    defenseColor={playColors?.defense}
+                  />
+                );
+              })}
 
             {/* Offensive players (rendered on top of defensive) */}
             {offensePx
               ?.filter((p) => {
-                // Read visibility from scene (Zustand source of truth) so that
-                // togglePlayerVisibility changes are reflected immediately
-                // without relying on local pixel state staying in sync.
+                // In readOnly mode, hide invisible players entirely.
+                // In editor mode, render all players (hidden ones appear as ghosts).
+                if (!readOnly) return true;
                 const scenePlayer = offenseVisible?.find((sp) => sp.position === p.position);
                 return scenePlayer ? scenePlayer.visible : p.visible;
               })
-              .map((p) => (
-                <PlayerToken
-                  key={`offense-${p.position}`}
-                  side="offense"
-                  position={p.position}
-                  cx={p.px}
-                  cy={p.py}
-                  courtBounds={{ width: courtSize.width, height: courtSize.height, minY: playAreaRef.current.offsetY > 0 ? playAreaRef.current.offsetY : undefined }}
-                  onDrag={(x, y) => handleOffenseDrag(p.position, x, y)}
-                  onDragEnd={(x, y) => handleOffenseDragEnd(p.position, x, y)}
-                  displayMode={displayMode}
-                  playerName={playerNames[`offense-${p.position}`]}
-                  radius={tokenRadius}
-                  offenseColor={playColors?.offense}
-                />
-              ))}
+              .map((p) => {
+                const scenePlayer = offenseVisible?.find((sp) => sp.position === p.position);
+                const isVisible = scenePlayer ? scenePlayer.visible : p.visible;
+                return (
+                  <PlayerToken
+                    key={`offense-${p.position}`}
+                    side="offense"
+                    position={p.position}
+                    cx={p.px}
+                    cy={p.py}
+                    courtBounds={{ width: courtSize.width, height: courtSize.height, minY: playAreaRef.current.offsetY > 0 ? playAreaRef.current.offsetY : undefined }}
+                    onDrag={(x, y) => handleOffenseDrag(p.position, x, y)}
+                    onDragEnd={(x, y) => handleOffenseDragEnd(p.position, x, y)}
+                    onTap={sceneId ? () => togglePlayerVisibility(sceneId, "offense", p.position) : undefined}
+                    visible={isVisible}
+                    displayMode={displayMode}
+                    playerName={playerNames[`offense-${p.position}`]}
+                    radius={tokenRadius}
+                    offenseColor={playColors?.offense}
+                  />
+                );
+              })}
 
             {/* Basketball — rendered on top of all players */}
             {effectiveBall && (

--- a/src/components/players/PlayerToken.tsx
+++ b/src/components/players/PlayerToken.tsx
@@ -51,6 +51,9 @@ const COLOR_TEXT_OFFENSE = "#FFFFFF";
 // Types
 // ---------------------------------------------------------------------------
 
+/** Pointer movement threshold (CSS px) below which a press is treated as a tap. */
+const TAP_THRESHOLD = 8;
+
 export interface PlayerTokenProps {
   /** "offense" or "defense" */
   side: "offense" | "defense";
@@ -64,6 +67,11 @@ export interface PlayerTokenProps {
   onDrag: (newCx: number, newCy: number) => void;
   /** Called when drag ends, signals store should be updated */
   onDragEnd: (newCx: number, newCy: number) => void;
+  /**
+   * Called when the token is tapped (pointer pressed + released without moving
+   * more than TAP_THRESHOLD pixels). Used to toggle player visibility.
+   */
+  onTap?: () => void;
   /** Bounding box (in CSS px) to clamp drag inside the court */
   courtBounds: { width: number; height: number; minY?: number };
   /**
@@ -90,6 +98,11 @@ export interface PlayerTokenProps {
    * Only used when side === "defense".
    */
   defenseColor?: string;
+  /**
+   * When false, the token is rendered as a ghost (semi-transparent, dashed
+   * border) to indicate the player is hidden. Defaults to true.
+   */
+  visible?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -103,12 +116,14 @@ export default function PlayerToken({
   cy,
   onDrag,
   onDragEnd,
+  onTap,
   courtBounds,
   displayMode = "numbers",
   playerName,
   radius = PLAYER_RADIUS,
   offenseColor,
   defenseColor,
+  visible = true,
 }: PlayerTokenProps) {
   const isDragging = useRef(false);
   const dragStart = useRef<{ mouseX: number; mouseY: number; playerCx: number; playerCy: number }>({
@@ -143,12 +158,16 @@ export default function PlayerToken({
       isDragging.current = false;
       const dx = e.clientX - dragStart.current.mouseX;
       const dy = e.clientY - dragStart.current.mouseY;
-      const { x, y } = clamp(dragStart.current.playerCx + dx, dragStart.current.playerCy + dy);
-      onDragEnd(x, y);
       window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("mouseup", handleMouseUp);
+      if (Math.sqrt(dx * dx + dy * dy) < TAP_THRESHOLD) {
+        onTap?.();
+        return;
+      }
+      const { x, y } = clamp(dragStart.current.playerCx + dx, dragStart.current.playerCy + dy);
+      onDragEnd(x, y);
     },
-    [clamp, onDragEnd, handleMouseMove],
+    [clamp, onDragEnd, onTap, handleMouseMove],
   );
 
   const handleMouseDown = useCallback(
@@ -181,17 +200,21 @@ export default function PlayerToken({
     (e: TouchEvent) => {
       if (!isDragging.current) return;
       isDragging.current = false;
+      window.removeEventListener("touchmove", handleTouchMove);
+      window.removeEventListener("touchend", handleTouchEnd);
       const touch = e.changedTouches[0];
       if (touch) {
         const dx = touch.clientX - dragStart.current.mouseX;
         const dy = touch.clientY - dragStart.current.mouseY;
+        if (Math.sqrt(dx * dx + dy * dy) < TAP_THRESHOLD) {
+          onTap?.();
+          return;
+        }
         const { x, y } = clamp(dragStart.current.playerCx + dx, dragStart.current.playerCy + dy);
         onDragEnd(x, y);
       }
-      window.removeEventListener("touchmove", handleTouchMove);
-      window.removeEventListener("touchend", handleTouchEnd);
     },
-    [clamp, onDragEnd, handleTouchMove],
+    [clamp, onDragEnd, onTap, handleTouchMove],
   );
 
   const handleTouchStart = useCallback(
@@ -242,28 +265,34 @@ export default function PlayerToken({
   // Defense label sits above the X mark; scale the offset with radius
   const textDy = isOffense ? 0 : -Math.round(radius * 7 / PLAYER_RADIUS);
 
+  const ghostOpacity = visible ? 1 : 0.35;
+  const dashArray = visible ? undefined : `${Math.round(radius * 0.6)} ${Math.round(radius * 0.4)}`;
+
   return (
     <g
       transform={`translate(${cx}, ${cy})`}
       onMouseDown={handleMouseDown}
       onTouchStart={handleTouchStart}
-      style={{ cursor: "grab" }}
+      style={{ cursor: "grab", opacity: ghostOpacity }}
       role="button"
-      aria-label={`${isOffense ? "Offensive" : "Defensive"} player ${position}`}
+      aria-label={`${isOffense ? "Offensive" : "Defensive"} player ${position}${visible ? "" : " (hidden)"}`}
     >
       {/* Drop shadow */}
-      <circle
-        r={radius}
-        cx={1}
-        cy={2}
-        fill="rgba(0,0,0,0.25)"
-      />
+      {visible && (
+        <circle
+          r={radius}
+          cx={1}
+          cy={2}
+          fill="rgba(0,0,0,0.25)"
+        />
+      )}
       {/* Main circle */}
       <circle
         r={radius}
         fill={fillColor}
         stroke={strokeColor}
         strokeWidth={scaledStrokeWidth}
+        strokeDasharray={dashArray}
       />
       {/* Defensive X lines */}
       {!isOffense && (


### PR DESCRIPTION
## Summary

- **PlayerToken**: new `visible` prop renders hidden players as ghosts (35% opacity, dashed outline, no shadow); new `onTap` prop fires when a press+release moves < 8 px
- **CourtWithPlayers**: editor now renders _all_ players — hidden ones show as ghosts and tapping them calls `togglePlayerVisibility`; `readOnly` mode (presentation, export) still filters invisible players out entirely

## Test plan

- [ ] Tap an offense token → it becomes a ghost (semi-transparent, dashed). Tap again → it comes back
- [ ] Tap a defense token → same ghost behavior
- [ ] Drag a token (move > 8 px) → no accidental toggle, normal drag behavior
- [ ] Touch tap works on mobile / touch screen
- [ ] Ghost tokens still drag normally (position is preserved while hidden)
- [ ] Presentation mode / export: hidden players are not visible (no ghosts)
- [ ] Undo/redo restores visibility state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)