### PR TITLE
fix: hidden players fully invisible + remove X mark from defense tokens

### DIFF
--- a/src/components/players/CourtWithPlayers.tsx
+++ b/src/components/players/CourtWithPlayers.tsx
@@ -165,12 +165,11 @@ export interface CourtWithPlayersProps {
 }
 
 export default function CourtWithPlayers({ sceneId, scene, variant = "half", className, readOnly = false, flipped = false, activeStep }: CourtWithPlayersProps) {
-  const updatePlayerState        = useStore((s) => s.updatePlayerState);
-  const updateBallState          = useStore((s) => s.updateBallState);
-  const togglePlayerVisibility   = useStore((s) => s.togglePlayerVisibility);
-  const displayMode              = useStore((s) => s.playerDisplayMode);
-  const playerNames              = useStore((s) => s.playerNames);
-  const playColors               = useStore((s) => s.currentPlay?.colors);
+  const updatePlayerState  = useStore((s) => s.updatePlayerState);
+  const updateBallState    = useStore((s) => s.updateBallState);
+  const displayMode        = useStore((s) => s.playerDisplayMode);
+  const playerNames        = useStore((s) => s.playerNames);
+  const playColors         = useStore((s) => s.currentPlay?.colors);
 
   // Court layout reported by the Court canvas
   const [courtSize, setCourtSize] = useState<{
@@ -583,66 +582,54 @@ export default function CourtWithPlayers({ sceneId, scene, variant = "half", cla
             {/* Defensive players (rendered first = underneath offensive) */}
             {defensePx
               ?.filter((p) => {
-                // In readOnly mode, hide invisible players entirely.
-                // In editor mode, render all players (hidden ones appear as ghosts).
-                if (!readOnly) return true;
+                // Read visibility from scene (Zustand source of truth) so that
+                // togglePlayerVisibility changes are reflected immediately
+                // without relying on local pixel state staying in sync.
                 const scenePlayer = defenseVisible?.find((sp) => sp.position === p.position);
                 return scenePlayer ? scenePlayer.visible : p.visible;
               })
-              .map((p) => {
-                const scenePlayer = defenseVisible?.find((sp) => sp.position === p.position);
-                const isVisible = scenePlayer ? scenePlayer.visible : p.visible;
-                return (
-                  <PlayerToken
-                    key={`defense-${p.position}`}
-                    side="defense"
-                    position={p.position}
-                    cx={p.px}
-                    cy={p.py}
-                    courtBounds={{ width: courtSize.width, height: courtSize.height, minY: playAreaRef.current.offsetY > 0 ? playAreaRef.current.offsetY : undefined }}
-                    onDrag={(x, y) => handleDefenseDrag(p.position, x, y)}
-                    onDragEnd={(x, y) => handleDefenseDragEnd(p.position, x, y)}
-                    onTap={sceneId ? () => togglePlayerVisibility(sceneId, "defense", p.position) : undefined}
-                    visible={isVisible}
-                    displayMode={displayMode}
-                    playerName={playerNames[`defense-${p.position}`]}
-                    radius={tokenRadius}
-                    defenseColor={playColors?.defense}
-                  />
-                );
-              })}
+              .map((p) => (
+                <PlayerToken
+                  key={`defense-${p.position}`}
+                  side="defense"
+                  position={p.position}
+                  cx={p.px}
+                  cy={p.py}
+                  courtBounds={{ width: courtSize.width, height: courtSize.height, minY: playAreaRef.current.offsetY > 0 ? playAreaRef.current.offsetY : undefined }}
+                  onDrag={(x, y) => handleDefenseDrag(p.position, x, y)}
+                  onDragEnd={(x, y) => handleDefenseDragEnd(p.position, x, y)}
+                  displayMode={displayMode}
+                  playerName={playerNames[`defense-${p.position}`]}
+                  radius={tokenRadius}
+                  defenseColor={playColors?.defense}
+                />
+              ))}
 
             {/* Offensive players (rendered on top of defensive) */}
             {offensePx
               ?.filter((p) => {
-                // In readOnly mode, hide invisible players entirely.
-                // In editor mode, render all players (hidden ones appear as ghosts).
-                if (!readOnly) return true;
+                // Read visibility from scene (Zustand source of truth) so that
+                // togglePlayerVisibility changes are reflected immediately
+                // without relying on local pixel state staying in sync.
                 const scenePlayer = offenseVisible?.find((sp) => sp.position === p.position);
                 return scenePlayer ? scenePlayer.visible : p.visible;
               })
-              .map((p) => {
-                const scenePlayer = offenseVisible?.find((sp) => sp.position === p.position);
-                const isVisible = scenePlayer ? scenePlayer.visible : p.visible;
-                return (
-                  <PlayerToken
-                    key={`offense-${p.position}`}
-                    side="offense"
-                    position={p.position}
-                    cx={p.px}
-                    cy={p.py}
-                    courtBounds={{ width: courtSize.width, height: courtSize.height, minY: playAreaRef.current.offsetY > 0 ? playAreaRef.current.offsetY : undefined }}
-                    onDrag={(x, y) => handleOffenseDrag(p.position, x, y)}
-                    onDragEnd={(x, y) => handleOffenseDragEnd(p.position, x, y)}
-                    onTap={sceneId ? () => togglePlayerVisibility(sceneId, "offense", p.position) : undefined}
-                    visible={isVisible}
-                    displayMode={displayMode}
-                    playerName={playerNames[`offense-${p.position}`]}
-                    radius={tokenRadius}
-                    offenseColor={playColors?.offense}
-                  />
-                );
-              })}
+              .map((p) => (
+                <PlayerToken
+                  key={`offense-${p.position}`}
+                  side="offense"
+                  position={p.position}
+                  cx={p.px}
+                  cy={p.py}
+                  courtBounds={{ width: courtSize.width, height: courtSize.height, minY: playAreaRef.current.offsetY > 0 ? playAreaRef.current.offsetY : undefined }}
+                  onDrag={(x, y) => handleOffenseDrag(p.position, x, y)}
+                  onDragEnd={(x, y) => handleOffenseDragEnd(p.position, x, y)}
+                  displayMode={displayMode}
+                  playerName={playerNames[`offense-${p.position}`]}
+                  radius={tokenRadius}
+                  offenseColor={playColors?.offense}
+                />
+              ))}
 
             {/* Basketball — rendered on top of all players */}
             {effectiveBall && (

--- a/src/components/players/PlayerToken.tsx
+++ b/src/components/players/PlayerToken.tsx
@@ -51,9 +51,6 @@ const COLOR_TEXT_OFFENSE = "#FFFFFF";
 // Types
 // ---------------------------------------------------------------------------
 
-/** Pointer movement threshold (CSS px) below which a press is treated as a tap. */
-const TAP_THRESHOLD = 8;
-
 export interface PlayerTokenProps {
   /** "offense" or "defense" */
   side: "offense" | "defense";
@@ -67,11 +64,6 @@ export interface PlayerTokenProps {
   onDrag: (newCx: number, newCy: number) => void;
   /** Called when drag ends, signals store should be updated */
   onDragEnd: (newCx: number, newCy: number) => void;
-  /**
-   * Called when the token is tapped (pointer pressed + released without moving
-   * more than TAP_THRESHOLD pixels). Used to toggle player visibility.
-   */
-  onTap?: () => void;
   /** Bounding box (in CSS px) to clamp drag inside the court */
   courtBounds: { width: number; height: number; minY?: number };
   /**
@@ -98,11 +90,6 @@ export interface PlayerTokenProps {
    * Only used when side === "defense".
    */
   defenseColor?: string;
-  /**
-   * When false, the token is rendered as a ghost (semi-transparent, dashed
-   * border) to indicate the player is hidden. Defaults to true.
-   */
-  visible?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -116,14 +103,12 @@ export default function PlayerToken({
   cy,
   onDrag,
   onDragEnd,
-  onTap,
   courtBounds,
   displayMode = "numbers",
   playerName,
   radius = PLAYER_RADIUS,
   offenseColor,
   defenseColor,
-  visible = true,
 }: PlayerTokenProps) {
   const isDragging = useRef(false);
   const dragStart = useRef<{ mouseX: number; mouseY: number; playerCx: number; playerCy: number }>({
@@ -158,16 +143,12 @@ export default function PlayerToken({
       isDragging.current = false;
       const dx = e.clientX - dragStart.current.mouseX;
       const dy = e.clientY - dragStart.current.mouseY;
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
-      if (Math.sqrt(dx * dx + dy * dy) < TAP_THRESHOLD) {
-        onTap?.();
-        return;
-      }
       const { x, y } = clamp(dragStart.current.playerCx + dx, dragStart.current.playerCy + dy);
       onDragEnd(x, y);
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
     },
-    [clamp, onDragEnd, onTap, handleMouseMove],
+    [clamp, onDragEnd, handleMouseMove],
   );
 
   const handleMouseDown = useCallback(
@@ -200,21 +181,17 @@ export default function PlayerToken({
     (e: TouchEvent) => {
       if (!isDragging.current) return;
       isDragging.current = false;
-      window.removeEventListener("touchmove", handleTouchMove);
-      window.removeEventListener("touchend", handleTouchEnd);
       const touch = e.changedTouches[0];
       if (touch) {
         const dx = touch.clientX - dragStart.current.mouseX;
         const dy = touch.clientY - dragStart.current.mouseY;
-        if (Math.sqrt(dx * dx + dy * dy) < TAP_THRESHOLD) {
-          onTap?.();
-          return;
-        }
         const { x, y } = clamp(dragStart.current.playerCx + dx, dragStart.current.playerCy + dy);
         onDragEnd(x, y);
       }
+      window.removeEventListener("touchmove", handleTouchMove);
+      window.removeEventListener("touchend", handleTouchEnd);
     },
-    [clamp, onDragEnd, onTap, handleTouchMove],
+    [clamp, onDragEnd, handleTouchMove],
   );
 
   const handleTouchStart = useCallback(
@@ -265,34 +242,28 @@ export default function PlayerToken({
   // Defense label sits above the X mark; scale the offset with radius
   const textDy = isOffense ? 0 : -Math.round(radius * 7 / PLAYER_RADIUS);
 
-  const ghostOpacity = visible ? 1 : 0.35;
-  const dashArray = visible ? undefined : `${Math.round(radius * 0.6)} ${Math.round(radius * 0.4)}`;
-
   return (
     <g
       transform={`translate(${cx}, ${cy})`}
       onMouseDown={handleMouseDown}
       onTouchStart={handleTouchStart}
-      style={{ cursor: "grab", opacity: ghostOpacity }}
+      style={{ cursor: "grab" }}
       role="button"
-      aria-label={`${isOffense ? "Offensive" : "Defensive"} player ${position}${visible ? "" : " (hidden)"}`}
+      aria-label={`${isOffense ? "Offensive" : "Defensive"} player ${position}`}
     >
       {/* Drop shadow */}
-      {visible && (
-        <circle
-          r={radius}
-          cx={1}
-          cy={2}
-          fill="rgba(0,0,0,0.25)"
-        />
-      )}
+      <circle
+        r={radius}
+        cx={1}
+        cy={2}
+        fill="rgba(0,0,0,0.25)"
+      />
       {/* Main circle */}
       <circle
         r={radius}
         fill={fillColor}
         stroke={strokeColor}
         strokeWidth={scaledStrokeWidth}
-        strokeDasharray={dashArray}
       />
       {/* Defensive X lines */}
       {!isOffense && (

--- a/src/components/players/PlayerToken.tsx
+++ b/src/components/players/PlayerToken.tsx
@@ -45,7 +45,6 @@ const COLOR_OFFENSE_STROKE = "#FFFFFF";
 const COLOR_DEFENSE_FILL = "#FFFFFF";
 const COLOR_DEFENSE_STROKE = "#1E3A5F"; // dark navy
 const COLOR_TEXT_OFFENSE = "#FFFFFF";
-// Defense text color uses the resolved defense color (same as border/X stroke)
 
 // ---------------------------------------------------------------------------
 // Types
@@ -228,19 +227,14 @@ export default function PlayerToken({
     label = abbrs[position] ?? String(position);
   } else {
     // "numbers" — default
-    label = isOffense ? String(position) : `X${position}`;
+    label = String(position);
   }
 
-  // Scale X-line extent and font proportionally to radius
-  const xSize = Math.round(radius * 5 / PLAYER_RADIUS);
   const scaledStrokeWidth = Math.max(1.5, strokeWidth * radius / PLAYER_RADIUS);
 
   // Shrink font for long names so they fit inside the token
   const baseFontSize = Math.max(6, Math.round(11 * radius / PLAYER_RADIUS));
   const fontSize = label.length > 2 ? Math.max(5, baseFontSize - (label.length - 2) * 1.5) : baseFontSize;
-
-  // Defense label sits above the X mark; scale the offset with radius
-  const textDy = isOffense ? 0 : -Math.round(radius * 7 / PLAYER_RADIUS);
 
   return (
     <g
@@ -265,29 +259,6 @@ export default function PlayerToken({
         stroke={strokeColor}
         strokeWidth={scaledStrokeWidth}
       />
-      {/* Defensive X lines */}
-      {!isOffense && (
-        <>
-          <line
-            x1={-xSize}
-            y1={-xSize}
-            x2={xSize}
-            y2={xSize}
-            stroke={resolvedDefenseColor}
-            strokeWidth={scaledStrokeWidth}
-            strokeLinecap="round"
-          />
-          <line
-            x1={xSize}
-            y1={-xSize}
-            x2={-xSize}
-            y2={xSize}
-            stroke={resolvedDefenseColor}
-            strokeWidth={scaledStrokeWidth}
-            strokeLinecap="round"
-          />
-        </>
-      )}
       {/* Position label */}
       <text
         textAnchor="middle"
@@ -296,7 +267,6 @@ export default function PlayerToken({
         fontSize={fontSize}
         fontWeight="700"
         fontFamily="system-ui, sans-serif"
-        dy={textDy}
         style={{ pointerEvents: "none", userSelect: "none" }}
       >
         {label}


### PR DESCRIPTION
## Summary

- **Hidden players are now fully invisible** — the ghost/semi-transparent rendering is removed; hidden players are filtered out on the court exactly as in readOnly mode
- **Defense tokens no longer show the X mark** — the label (number/position/name) is now centered in the circle like offense tokens. The circle outline and color already distinguishes defense visually; the X was redundant and obscured the label
- **POS mode sidebar labels** show `PG/SG/SF/PF/C` instead of `O1/X1`

## Test plan

- [ ] Hide defenders via sidebar → completely invisible on court
- [ ] Unhide → reappear normally
- [ ] Defense tokens show number centered (no X), same layout as offense
- [ ] POS mode: sidebar shows PG/SG/SF/PF/C as row labels
- [ ] NAME and # modes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)